### PR TITLE
replace session/token if 2 events created events are sent

### DIFF
--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -175,7 +175,14 @@ class TestUser(BaseIntegrationTest):
         self._session.expire_all()
         assert_that(user.sessions, contains(has_properties(uuid=session_uuid)))
 
-        # twice
+        # twice with same instance
+        self._dao.user.add_session(user, session)
+
+        self._session.expire_all()
+        assert_that(user.sessions, contains(has_properties(uuid=session_uuid)))
+
+        # twice with different instances
+        session = Session(uuid=session_uuid)
         self._dao.user.add_session(user, session)
 
         self._session.expire_all()
@@ -204,7 +211,14 @@ class TestUser(BaseIntegrationTest):
         self._session.expire_all()
         assert_that(user.refresh_tokens, contains(has_properties(client_id=token_client_id)))
 
-        # twice
+        # twice with same instance
+        self._dao.user.add_refresh_token(user, token)
+
+        self._session.expire_all()
+        assert_that(user.refresh_tokens, contains(has_properties(client_id=token_client_id)))
+
+        # twice with different instances
+        token = RefreshToken(client_id=token_client_id)
         self._dao.user.add_refresh_token(user, token)
 
         self._session.expire_all()

--- a/wazo_chatd/database/queries/user.py
+++ b/wazo_chatd/database/queries/user.py
@@ -67,9 +67,15 @@ class UserDAO:
         return query.filter(User.tenant_uuid.in_(tenant_uuids))
 
     def add_session(self, user, session):
-        if session not in user.sessions:
-            user.sessions.append(session)
-            self.session.flush()
+        if session in user.sessions:
+            return
+
+        for existing_session in user.sessions:
+            if existing_session.uuid == session.uuid:
+                user.sessions.remove(existing_session)
+
+        user.sessions.append(session)
+        self.session.flush()
 
     def remove_session(self, user, session):
         if session in user.sessions:
@@ -87,9 +93,15 @@ class UserDAO:
             self.session.flush()
 
     def add_refresh_token(self, user, refresh_token):
-        if refresh_token not in user.refresh_tokens:
-            user.refresh_tokens.append(refresh_token)
-            self.session.flush()
+        if refresh_token in user.refresh_tokens:
+            return
+
+        for existing_token in user.refresh_tokens:
+            if existing_token.client_id == refresh_token.client_id:
+                user.refresh_tokens.remove(existing_token)
+
+        user.refresh_tokens.append(refresh_token)
+        self.session.flush()
 
     def remove_refresh_token(self, user, refresh_token):
         if refresh_token in user.refresh_tokens:


### PR DESCRIPTION
Since session and refresh_token do not have any objects related, we
can easily replace them if we receive a second created event.

For other resources like tenant, user and line, it is a little bit more
risky. Because if we replace the resource, then every resources releated
to it will be removed