### PR TITLE
increate confd default timeout to 90

### DIFF
--- a/etc/wazo-chatd/config.yml
+++ b/etc/wazo-chatd/config.yml
@@ -46,6 +46,7 @@ amid:
 confd:
   host: localhost
   port: 9486
+  timeout: 90
   verify_certificate: /usr/share/xivo-certs/server.crt
 
 # consul connection informations

--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -47,7 +47,12 @@ _DEFAULT_CONFIG = {
         'exchange_headers_name': 'wazo-headers',
     },
     'amid': {'host': 'localhost', 'port': 9491, 'verify_certificate': _CERT_FILE},
-    'confd': {'host': 'localhost', 'port': 9486, 'verify_certificate': _CERT_FILE},
+    'confd': {
+        'host': 'localhost',
+        'port': 9486,
+        'timeout': 90,
+        'verify_certificate': _CERT_FILE,
+    },
     'consul': {
         'scheme': 'https',
         'host': 'localhost',


### PR DESCRIPTION
reason: It doesn't mind if the request is long, it's only used one time
for initialisation.