### PR TITLE
presence: fix when token belong to non pbx user

### DIFF
--- a/integration_tests/suite/test_db_presence_initiator.py
+++ b/integration_tests/suite/test_db_presence_initiator.py
@@ -38,3 +38,15 @@ class TestDBPresenceInitiator(BaseIntegrationTest):
 
         result = self._dao.session.find(session_uuid)
         assert_that(result, equal_to(None))
+
+    @fixtures.db.tenant(uuid=TENANT_UUID)
+    def test_initiate_refresh_token_when_no_user_associate(self, tenant):
+        client_id = 'my-client-id'
+        refresh_tokens = [
+            {'client_id': client_id, 'user_uuid': USER_UUID, 'tenant_uuid': TENANT_UUID}
+        ]
+
+        self.initiator.initiate_refresh_tokens(refresh_tokens)
+
+        result = self._dao.refresh_token.find(USER_UUID, client_id)
+        assert_that(result, equal_to(None))

--- a/integration_tests/suite/test_db_refresh_token.py
+++ b/integration_tests/suite/test_db_refresh_token.py
@@ -40,6 +40,15 @@ class TestRefreshToken(BaseIntegrationTest):
 
     @fixtures.db.refresh_token()
     @fixtures.db.refresh_token()
+    def test_find(self, refresh_token, _):
+        result = self._dao.refresh_token.find(refresh_token.user_uuid, refresh_token.client_id)
+        assert_that(result, equal_to(refresh_token))
+
+        result = self._dao.refresh_token.find(UNKNOWN_UUID, 'not-found')
+        assert_that(result, equal_to(None))
+
+    @fixtures.db.refresh_token()
+    @fixtures.db.refresh_token()
     def test_list(self, refresh_token_1, refresh_token_2):
         refresh_tokens = self._dao.refresh_token.list_()
         assert_that(refresh_tokens, has_items(refresh_token_1, refresh_token_2))

--- a/wazo_chatd/database/queries/refresh_token.py
+++ b/wazo_chatd/database/queries/refresh_token.py
@@ -1,6 +1,7 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import and_, text
 from sqlalchemy.orm import joinedload
 
 from ...exceptions import UnknownRefreshTokenException
@@ -18,6 +19,19 @@ class RefreshTokenDAO:
         if not refresh_token:
             raise UnknownRefreshTokenException(client_id, user_uuid)
         return refresh_token
+
+    def find(self, user_uuid, client_id):
+        return self._find_by(user_uuid=user_uuid, client_id=client_id)
+
+    def _find_by(self, **kwargs):
+        filter_ = text('true')
+
+        if 'user_uuid' in kwargs:
+            filter_ = and_(filter_, RefreshToken.user_uuid == kwargs['user_uuid'])
+        if 'client_id' in kwargs:
+            filter_ = and_(filter_, RefreshToken.client_id == kwargs['client_id'])
+
+        return self.session.query(RefreshToken).filter(filter_).first()
 
     def list_(self):
         return self.session.query(RefreshToken).options(joinedload('user')).all()

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -319,8 +319,8 @@ class Initiator:
     def _update_refresh_tokens(self, tokens):
         with session_scope():
             for token in tokens:
-                cached_token = self._dao.refresh_token.get(token['user_uuid'], token['client_id'])
-                if token['mobile'] != cached_token.mobile:
+                cached_token = self._dao.refresh_token.find(token['user_uuid'], token['client_id'])
+                if cached_token and token['mobile'] != cached_token.mobile:
                     cached_token.mobile = token['mobile']
                     self._dao.refresh_token.update(cached_token)
 


### PR DESCRIPTION
reason: some service users can have a refresh token and it should not
impact wazo-chatd