### PR TITLE
debian: add SyslogIdentifier on service file

### DIFF
--- a/debian/wazo-chatd.service
+++ b/debian/wazo-chatd.service
@@ -4,9 +4,9 @@ After=network.target
 Before=monit.service
 
 [Service]
+Environment=PYTHONUNBUFFERED=TRUE
 ExecStartPre=/usr/bin/install -o wazo-chatd -g wazo-chatd -d /run/wazo-chatd
-ExecStart=/usr/bin/python3 -u /usr/bin/wazo-chatd
-SyslogIdentifier=wazo-chatd
+ExecStart=/usr/bin/wazo-chatd
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/wazo-chatd.service
+++ b/debian/wazo-chatd.service
@@ -6,6 +6,7 @@ Before=monit.service
 [Service]
 ExecStartPre=/usr/bin/install -o wazo-chatd -g wazo-chatd -d /run/wazo-chatd
 ExecStart=/usr/bin/python3 -u /usr/bin/wazo-chatd
+SyslogIdentifier=wazo-chatd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reason: to see the daemon name in the journalctl/syslog instead of
`python3`