### PR TITLE
use confd without ssl by default

### DIFF
--- a/etc/wazo-chatd/config.yml
+++ b/etc/wazo-chatd/config.yml
@@ -48,9 +48,9 @@ amid:
 confd:
   host: localhost
   port: 9486
+  prefix: null
+  https: false
   timeout: 90
-  https: true
-  verify_certificate: /usr/share/xivo-certs/server.crt
 
 # consul connection informations
 consul:

--- a/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
@@ -8,7 +8,6 @@ bus:
   host: rabbitmq
 confd:
   host: confd
-  verify_certificate: false
 service_discovery:
   enabled: false
 

--- a/integration_tests/suite/helpers/confd.py
+++ b/integration_tests/suite/helpers/confd.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -10,7 +10,7 @@ class ConfdClient:
         self._port = port
 
     def url(self, *parts):
-        return 'https://{host}:{port}/{path}'.format(
+        return 'http://{host}:{port}/{path}'.format(
             host=self._host, port=self._port, path='/'.join(parts)
         )
 
@@ -20,4 +20,4 @@ class ConfdClient:
             'response': 'users',
             'content': {user['uuid']: user for user in mock_users},
         }
-        requests.post(url, json=body, verify=False)
+        requests.post(url, json=body)

--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -51,9 +51,9 @@ _DEFAULT_CONFIG = {
     'confd': {
         'host': 'localhost',
         'port': 9486,
+        'prefix': None,
+        'https': False,
         'timeout': 90,
-        'https': True,
-        'verify_certificate': _CERT_FILE,
     },
     'consul': {
         'scheme': 'http',


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/32

Jira-Issue: https://wazo-dev.atlassian.net/browse/WAZO-1747