### PR TITLE
Pull request for reduce-docker-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-buster
+FROM python:3.7-slim-buster
 
 COPY ./contribs/docker/certs /usr/share/xivo-certs
 RUN true \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,30 @@
-FROM python:3.7-slim-buster
+FROM python:3.7-slim-buster AS compile-image
 
+
+RUN python -m venv /opt/venv
+# Activate virtual env
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY . /usr/src/wazo-chatd
+WORKDIR /usr/src/wazo-chatd
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+FROM python:3.7-slim AS build-image
+COPY --from=compile-image /opt/venv /opt/venv
+
+COPY ./etc/. /etc/
 COPY ./contribs/docker/certs /usr/share/xivo-certs
 RUN true \
     && adduser --quiet --system --group --home /var/lib/wazo-chatd wazo-chatd \
     && mkdir -p /etc/wazo-chatd/conf.d \
     && install -d -o wazo-chatd -g wazo-chatd /run/wazo-chatd/ \
     && install -o wazo-chatd -g wazo-chatd /dev/null /var/log/wazo-chatd.log \
-    && apt-get -yqq autoremove \
     && openssl req -x509 -newkey rsa:4096 -keyout /usr/share/xivo-certs/server.key -out /usr/share/xivo-certs/server.crt -nodes -config /usr/share/xivo-certs/openssl.cfg -days 3650 \
     && chown wazo-chatd:wazo-chatd /usr/share/xivo-certs/*
 
-COPY . /usr/src/wazo-chatd
-WORKDIR /usr/src/wazo-chatd
-RUN true \
-  && pip install -r /usr/src/wazo-chatd/requirements.txt \
-  && python setup.py install \
-  && cp -r etc/* /etc
-
 EXPOSE 9304
 
+# Activate virtual env
+ENV PATH="/opt/venv/bin:$PATH"
 CMD ["wazo-chatd"]

--- a/integration_tests/Dockerfile-chatd
+++ b/integration_tests/Dockerfile-chatd
@@ -6,5 +6,3 @@ COPY . /usr/src/wazo-chatd
 
 WORKDIR /usr/src/wazo-chatd
 RUN python setup.py develop
-
-CMD ["/usr/local/bin/wazo-chatd", "-d"]

--- a/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
@@ -1,3 +1,4 @@
+debug: true
 db_uri: postgresql://wazo-chatd:Secr7t@postgres/wazo-chatd
 auth:
   host: auth

--- a/integration_tests/suite/test_presences.py
+++ b/integration_tests/suite/test_presences.py
@@ -221,7 +221,7 @@ class TestPresence(BaseIntegrationTest):
     @fixtures.db.user(state='away')
     def test_update(self, user):
         user_args = {'uuid': user.uuid, 'state': 'invisible', 'status': 'custom status'}
-        routing_key = 'chatd.users.*.presences.updated'.format(uuid=user.uuid)
+        routing_key = 'chatd.users.*.presences.updated'
         event_accumulator = self.bus.accumulator(routing_key)
 
         self.chatd.user_presences.update(user_args)


### PR DESCRIPTION
 docker: use multi stage build

reason:
* original layer slim-buster: 155MB
* without multi-stage: 282MB = wazo layers: 127MB
* with multi-stage: 221MB = wazo layers: 66MB

It reduces wazo weight by 52% for pure python dependencies. For services that
need to compile their deps, it will be much higher