### PR TITLE
avoid to return 404 on unknown uuid from query string

### DIFF
--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -19,7 +19,7 @@ from hamcrest import (
 from sqlalchemy.inspection import inspect
 
 from wazo_chatd.database.models import User, Session, Line, RefreshToken
-from wazo_chatd.exceptions import UnknownUserException, UnknownUsersException
+from wazo_chatd.exceptions import UnknownUserException
 from xivo_test_helpers.hamcrest.raises import raises
 
 from .helpers import fixtures
@@ -116,21 +116,8 @@ class TestUser(DBIntegrationTest):
         result = self._dao.user.list_(tenant_uuids=None, uuids=[])
         assert_that(result, has_items(user_1, user_2, user_3))
 
-        assert_that(
-            calling(self._dao.user.list_).with_args(
-                tenant_uuids=None, uuids=[UNKNOWN_UUID]
-            ),
-            raises(
-                UnknownUsersException,
-                has_properties(
-                    status_code=404,
-                    id_='unknown-users',
-                    resource='users',
-                    details=is_not(none()),
-                    message=is_not(none()),
-                ),
-            ),
-        )
+        result = self._dao.user.list_(tenant_uuids=None, uuids=[UNKNOWN_UUID])
+        assert_that(result, empty())
 
     @fixtures.db.user(tenant_uuid=TENANT_1)
     @fixtures.db.user(tenant_uuid=TENANT_2)

--- a/integration_tests/suite/test_presences.py
+++ b/integration_tests/suite/test_presences.py
@@ -121,22 +121,15 @@ class TestPresence(APIIntegrationTest):
             ),
         )
 
-    def test_list_unknown_user_uuids(self):
-        # NOTE(fblackburn): list should not return error on unknown users
+    @fixtures.db.user()
+    def test_list_unknown_user_uuids(self, user_1):
+        presences = self.chatd.user_presences.list(user_uuids=[str(UNKNOWN_UUID)])
         assert_that(
-            calling(self.chatd.user_presences.list).with_args(
-                user_uuids=[str(UNKNOWN_UUID)]
-            ),
-            raises(
-                ChatdError,
-                has_properties(
-                    status_code=404,
-                    error_id='unknown-users',
-                    resource='users',
-                    details=is_not(none()),
-                    message=is_not(none()),
-                    timestamp=is_not(none()),
-                ),
+            presences,
+            has_entries(
+                items=empty(),
+                total=equal_to(1),
+                filtered=equal_to(0),
             ),
         )
 

--- a/wazo_chatd/database/queries/user.py
+++ b/wazo_chatd/database/queries/user.py
@@ -3,7 +3,7 @@
 
 from sqlalchemy import text
 
-from ...exceptions import UnknownUserException, UnknownUsersException
+from ...exceptions import UnknownUserException
 from ..helpers import get_dao_session
 from ..models import User
 
@@ -33,17 +33,12 @@ class UserDAO:
         return user
 
     def list_(self, tenant_uuids, uuids=None, **filter_parameters):
-        users = self._get_users_query(
-            tenant_uuids, uuids=uuids, **filter_parameters
-        ).all()
-
-        if uuids:
-            found_uuids = set([user.uuid for user in users])
-            given_uuids = set(uuids)
-            if len(found_uuids) != len(given_uuids):
-                raise UnknownUsersException(list(given_uuids - found_uuids))
-
-        return users
+        query = self._get_users_query(
+            tenant_uuids,
+            uuids=uuids,
+            **filter_parameters,
+        )
+        return query.all()
 
     def count(self, tenant_uuids, **filter_parameters):
         return self._get_users_query(tenant_uuids, **filter_parameters).count()

--- a/wazo_chatd/exceptions.py
+++ b/wazo_chatd/exceptions.py
@@ -11,15 +11,6 @@ class UnknownUserException(APIException):
         super().__init__(404, msg, 'unknown-user', details, 'users')
 
 
-class UnknownUsersException(APIException):
-    def __init__(self, user_uuids):
-        msg = 'No such users: {}'.format(
-            ', '.join(map(lambda uuid: f'"{uuid}"', user_uuids))
-        )
-        details = {'uuids': [str(uuid) for uuid in user_uuids]}
-        super().__init__(404, msg, 'unknown-users', details, 'users')
-
-
 class UnknownTenantException(APIException):
     def __init__(self, tenant_uuid):
         msg = f'No such tenant: "{tenant_uuid}"'


### PR DESCRIPTION
reason: when listing users with wrong filter, we should return empty
result instead of error code