### PR TITLE
intiator: catch timeout errors

### DIFF
--- a/wazo_chatd/plugins/presences/initiator_thread.py
+++ b/wazo_chatd/plugins/presences/initiator_thread.py
@@ -48,7 +48,7 @@ class InitiatorThread(object):
         logger.debug('Starting presence initialization')
         try:
             self._initiator.initiate()
-        except (requests.ConnectionError, requests.HTTPError, SQLAlchemyError) as e:
+        except (requests.RequestException, SQLAlchemyError) as e:
             self._retry_time = next(self._retry_time_failed)
             logger.warning(
                 'Error to fetch data for initialization (%s). Retrying in %s seconds...',


### PR DESCRIPTION
Why:

* When the machine starts, wazo-auth may take some time to answer
* requests Timeout is not a ConnectionError or a HTTPError
