### PR TITLE
use flask helpers to avoid duplicate requests

### DIFF
--- a/wazo_chatd/plugin_helpers/tenant.py
+++ b/wazo_chatd/plugin_helpers/tenant.py
@@ -1,26 +1,11 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from requests import HTTPError
-
-from xivo.tenant_flask_helpers import Tenant, auth_client, token
+from xivo.tenant_flask_helpers import Tenant, token
 
 
 def get_tenant_uuids(recurse=False):
-    tenant = Tenant.autodetect().uuid
-
+    tenant_uuid = Tenant.autodetect().uuid
     if not recurse:
-        return [tenant]
-
-    auth_client.set_token(token.uuid)
-
-    try:
-        tenants = auth_client.tenants.list(tenant_uuid=tenant)['items']
-    except HTTPError as e:
-        response = getattr(e, 'response', None)
-        status_code = getattr(response, 'status_code', None)
-        if status_code == 401:
-            return [tenant]
-        raise
-
-    return [tenant['uuid'] for tenant in tenants]
+        return [tenant_uuid]
+    return [tenant.uuid for tenant in token.visible_tenants(tenant_uuid)]


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/60

reason: when using recurse=True, flask helpers already fetch tenants. So
instead to fetch list twice, we use the same list