### PR TITLE
presence: change ringing to talking for the caller

### DIFF
--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -373,7 +373,7 @@ class TestEventHandler(APIIntegrationTest):
             result = self._session.query(models.Channel).all()
             assert_that(
                 result,
-                has_items(has_properties(name=channel_name, state='ringing')),
+                has_items(has_properties(name=channel_name, state='talking')),
             )
 
         until.assert_(channel_created, tries=3)
@@ -384,7 +384,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     data=has_entries(
-                        lines=contains(has_entries(id=line_id, state='ringing'))
+                        lines=contains(has_entries(id=line_id, state='talking'))
                     )
                 )
             ),

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -42,7 +42,7 @@ CHANNEL_STATE_MAP = {
     'Rsrvd': 'undefined',
     'OffHook': 'undefined',
     'Dialing': 'undefined',
-    'Ring': 'ringing',
+    'Ring': 'talking',
     'Ringing': 'ringing',
     'Up': 'talking',
     'Busy': 'talking',


### PR DESCRIPTION
reason: allow to distinguish caller and callee. It allows to make logic
only on the phone that receive a call (ex: call pickup). For now, we cannot add a
new state to keep compatibility with external applications
But should be done in a future release