### PR TITLE
freeze sqlalchemy version for tests

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -12,6 +12,6 @@ https://github.com/wazo-platform/xivo-test-helpers/archive/master.zip
 
 # for database tests
 psycopg2-binary
-sqlalchemy
-sqlalchemy_utils
+sqlalchemy==1.2.18
+sqlalchemy_utils==0.32.21
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip


### PR DESCRIPTION
reason: latest sqlalchemy version (1.4.0) break latest sqlalchemy_utils
(0.36.8)