### PR TITLE
Pull request for avoid-hardcoded-token-test

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -12,7 +12,6 @@ services:
     volumes:
       - ../..:/usr/src/wazo-chatd:ro
       - ./etc/wazo-chatd/conf.d/50-default.yml:/etc/wazo-chatd/conf.d/50-default.yml:ro
-      - ./key-file.yml:/tmp/key-file.yml:ro
       # - '${LOCAL_GIT_REPOS}/xivo-lib-python/xivo:/opt/venv/lib/python3.7/site-packages/xivo'
       # - '${LOCAL_GIT_REPOS}/xivo-bus/xivo_bus:/opt/venv/lib/python3.7/site-packages/xivo_bus'
       # - '${LOCAL_GIT_REPOS}/wazo-auth-client/wazo_auth_client:/opt/venv/lib/python3.7/site-packages/wazo_auth_client'

--- a/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
+++ b/integration_tests/assets/etc/wazo-chatd/conf.d/50-default.yml
@@ -4,7 +4,8 @@ rest_api:
 db_uri: postgresql://wazo-chatd:Secr7t@postgres/wazo-chatd
 auth:
   host: auth
-  key_file: /tmp/key-file.yml
+  username: chatd-service
+  password: chatd-password
 amid:
   host: amid
 bus:

--- a/integration_tests/assets/key-file.yml
+++ b/integration_tests/assets/key-file.yml
@@ -1,2 +1,0 @@
-service_id: not-important
-service_key: not-important

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -71,10 +71,14 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.chatd = cls.make_chatd()
-        cls.auth = cls.make_auth()
+        cls.reset_clients()
         cls.create_token()
         cls.wait_strategy.wait(cls)
+
+    @classmethod
+    def reset_clients(cls):
+        cls.chatd = cls.make_chatd()
+        cls.auth = cls.make_auth()
 
     @classmethod
     def create_token(cls):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -71,14 +71,29 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.reset_clients()
+        cls.chatd = cls.make_chatd()
+        cls.auth = cls.make_auth()
         cls.create_token()
         cls.wait_strategy.wait(cls)
 
     @classmethod
-    def reset_clients(cls):
-        cls.chatd = cls.make_chatd()
+    def start_auth_service(cls):
+        cls.start_service('auth')
         cls.auth = cls.make_auth()
+        cls.create_token()
+
+    @classmethod
+    def stop_auth_service(cls):
+        cls.stop_service('auth')
+
+    @classmethod
+    def start_chatd_service(cls):
+        cls.start_service('chatd')
+        cls.chatd = cls.make_chatd()
+
+    @classmethod
+    def stop_chatd_service(cls):
+        cls.stop_service('chatd')
 
     @classmethod
     def create_token(cls):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -11,8 +11,11 @@ from wazo_chatd_client import Client as ChatdClient
 from wazo_chatd.database.queries import DAO
 from wazo_chatd.database.helpers import init_db, Session
 
-from xivo_test_helpers.auth import MockUserToken
-from xivo_test_helpers.auth import AuthClient
+from xivo_test_helpers.auth import (
+    AuthClient,
+    MockCredentials,
+    MockUserToken,
+)
 from xivo_test_helpers.asset_launching_test_case import (
     AssetLaunchingTestCase,
     NoSuchPort,
@@ -31,13 +34,12 @@ from .wait_strategy import (
 DB_URI = 'postgresql://wazo-chatd:Secr7t@127.0.0.1:{port}'
 DB_ECHO = os.getenv('DB_ECHO', '').lower() == 'true'
 
-CHATD_TOKEN_TENANT_UUID = uuid.UUID('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeee1')
-CHATD_TOKEN_UUID = 'valid-token-multitenant'
-
 TOKEN_UUID = uuid.UUID('00000000-0000-0000-0000-000000000101')
 TOKEN_TENANT_UUID = uuid.UUID('00000000-0000-0000-0000-000000000201')
 TOKEN_SUBTENANT_UUID = uuid.UUID('00000000-0000-0000-0000-000000000202')
 TOKEN_USER_UUID = uuid.UUID('00000000-0000-0000-0000-000000000301')
+
+CHATD_TOKEN_TENANT_UUID = TOKEN_TENANT_UUID
 
 UNKNOWN_UUID = uuid.UUID('00000000-0000-0000-0000-000000000000')
 WAZO_UUID = uuid.UUID('00000000-0000-0000-0000-0000000c4a7d')
@@ -91,12 +93,9 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
             },
         )
         auth_client.set_token(token)
+        credential = MockCredentials('chatd-service', 'chatd-password')
+        auth_client.set_valid_credentials(credential, str(TOKEN_UUID))
         auth_client.set_tenants(
-            {
-                'uuid': str(CHATD_TOKEN_TENANT_UUID),
-                'name': 'chatd-token',
-                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
-            },
             {
                 'uuid': str(TOKEN_TENANT_UUID),
                 'name': 'name1',

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -77,11 +77,8 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
         cls.wait_strategy.wait(cls)
 
     @classmethod
-    def create_token(cls, auth_client=None):
-        if not auth_client:
-            auth_client = cls.auth
-
-        if isinstance(auth_client, WrongClient):
+    def create_token(cls):
+        if isinstance(cls.auth, WrongClient):
             return
 
         token = MockUserToken(
@@ -92,10 +89,10 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
                 'tenant_uuid': str(TOKEN_TENANT_UUID),
             },
         )
-        auth_client.set_token(token)
+        cls.auth.set_token(token)
         credential = MockCredentials('chatd-service', 'chatd-password')
-        auth_client.set_valid_credentials(credential, str(TOKEN_UUID))
-        auth_client.set_tenants(
+        cls.auth.set_valid_credentials(credential, str(TOKEN_UUID))
+        cls.auth.set_tenants(
             {
                 'uuid': str(TOKEN_TENANT_UUID),
                 'name': 'name1',
@@ -221,8 +218,3 @@ class APIIntegrationTest(_BaseIntegrationTest):
         cls.auth = APIAssetLaunchingTestCase.make_auth()
         cls.confd = APIAssetLaunchingTestCase.make_confd()
         cls.bus = APIAssetLaunchingTestCase.make_bus()
-
-    @classmethod
-    def reset_auth(cls):
-        cls.auth = APIAssetLaunchingTestCase.make_auth()
-        APIAssetLaunchingTestCase.create_token(auth_client=cls.auth)

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -123,7 +123,7 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     def make_chatd(cls, token=str(TOKEN_UUID)):
         try:
             port = cls.service_port(9304, 'chatd')
-        except NoSuchService:
+        except (NoSuchService, NoSuchPort):
             return WrongClient('chatd')
         return ChatdClient(
             '127.0.0.1',
@@ -145,7 +145,7 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
     def make_auth(cls):
         try:
             port = cls.service_port(9497, 'auth')
-        except NoSuchService:
+        except (NoSuchService, NoSuchPort):
             return WrongClient('auth')
         return AuthClient('127.0.0.1', port=port)
 

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -18,9 +18,6 @@ from wazo_chatd_client.exceptions import ChatdError
 
 @use_asset('base')
 class TestConfig(APIIntegrationTest):
-    def tearDown(self):
-        self.reset_auth()
-
     def test_config(self):
         result = self.chatd.config.get()
         assert_that(result, has_key('rest_api'))
@@ -36,12 +33,11 @@ class TestConfig(APIIntegrationTest):
         APIAssetLaunchingTestCase.stop_service('chatd')
         APIAssetLaunchingTestCase.stop_service('auth')
         APIAssetLaunchingTestCase.start_service('chatd')
-
-        chatd_client = APIAssetLaunchingTestCase.make_chatd(CHATD_TOKEN_UUID)
+        self.reset_client()
 
         def _returns_503():
             try:
-                chatd_client.config.get()
+                self.chatd.config.get()
             except ChatdError as e:
                 assert e.status_code == 503
             except requests.RequestException as e:
@@ -50,10 +46,11 @@ class TestConfig(APIIntegrationTest):
         until.assert_(_returns_503, tries=10)
 
         APIAssetLaunchingTestCase.start_service('auth')
+        self.reset_client()
 
         def _not_return_503():
             try:
-                response = chatd_client.config.get()
+                response = self.chatd.config.get()
                 assert_that(response, has_key('debug'))
             except Exception as e:
                 raise AssertionError(e)

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -33,7 +33,8 @@ class TestConfig(APIIntegrationTest):
         APIAssetLaunchingTestCase.stop_service('chatd')
         APIAssetLaunchingTestCase.stop_service('auth')
         APIAssetLaunchingTestCase.start_service('chatd')
-        self.reset_client()
+        APIAssetLaunchingTestCase.reset_clients()
+        self.reset_clients()
 
         def _returns_503():
             try:
@@ -46,7 +47,9 @@ class TestConfig(APIIntegrationTest):
         until.assert_(_returns_503, tries=10)
 
         APIAssetLaunchingTestCase.start_service('auth')
-        self.reset_client()
+        APIAssetLaunchingTestCase.reset_clients()
+        APIAssetLaunchingTestCase.create_token()
+        self.reset_clients()
 
         def _not_return_503():
             try:

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -10,7 +10,7 @@ from .helpers.base import (
     APIIntegrationTest,
     use_asset,
     APIAssetLaunchingTestCase,
-    CHATD_TOKEN_UUID,
+    TOKEN_SUBTENANT_UUID,
 )
 
 from wazo_chatd_client.exceptions import ChatdError
@@ -22,12 +22,11 @@ class TestConfig(APIIntegrationTest):
         self.reset_auth()
 
     def test_config(self):
-        chatd_client = APIAssetLaunchingTestCase.make_chatd(CHATD_TOKEN_UUID)
-        result = chatd_client.config.get()
+        result = self.chatd.config.get()
         assert_that(result, has_key('rest_api'))
 
     def test_restrict_only_master_tenant(self):
-        chatd_client = APIAssetLaunchingTestCase.make_chatd()
+        chatd_client = APIAssetLaunchingTestCase.make_chatd(str(TOKEN_SUBTENANT_UUID))
         assert_that(
             calling(chatd_client.config.get),
             raises(ChatdError, has_properties('status_code', 401)),

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -30,10 +30,9 @@ class TestConfig(APIIntegrationTest):
         )
 
     def test_restrict_on_with_slow_wazo_auth(self):
-        APIAssetLaunchingTestCase.stop_service('chatd')
-        APIAssetLaunchingTestCase.stop_service('auth')
-        APIAssetLaunchingTestCase.start_service('chatd')
-        APIAssetLaunchingTestCase.reset_clients()
+        APIAssetLaunchingTestCase.stop_chatd_service()
+        APIAssetLaunchingTestCase.stop_auth_service()
+        APIAssetLaunchingTestCase.start_chatd_service()
         self.reset_clients()
 
         def _returns_503():
@@ -46,9 +45,7 @@ class TestConfig(APIIntegrationTest):
 
         until.assert_(_returns_503, tries=10)
 
-        APIAssetLaunchingTestCase.start_service('auth')
-        APIAssetLaunchingTestCase.reset_clients()
-        APIAssetLaunchingTestCase.create_token()
+        APIAssetLaunchingTestCase.start_auth_service()
         self.reset_clients()
 
         def _not_return_503():


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-test-helpers/pull/53

Note: to pass integration tests
* build wazo-auth-mock
* use `WAZO_TEST_NO_DOCKER_COMPOSE_PULL=1` variable