### PR TITLE
WAZO-2995 Group chat functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 23.01
+
+* Room can now have up to 100 users
+
 ## 22.17
 
 * New endpoint:

--- a/integration_tests/suite/test_user_room.py
+++ b/integration_tests/suite/test_user_room.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -95,9 +95,9 @@ class TestUserRoom(APIIntegrationTest):
             ),
         )
 
-    def _create_rooms(self, name, add_third_user):
+    def test_create(self):
         room_args = {
-            'name': name,
+            'name': 'test-room',
             'users': [
                 {
                     'uuid': str(TOKEN_USER_UUID),
@@ -107,13 +107,8 @@ class TestUserRoom(APIIntegrationTest):
                 {'uuid': UUID, 'tenant_uuid': UUID, 'wazo_uuid': UUID},
             ],
         }
-        if add_third_user:
-            room_args['users'].append(
-                {'uuid': UUID_2, 'tenant_uuid': UUID_2, 'wazo_uuid': UUID_2}
-            )
-
-        routing_key = 'chatd.users.*.rooms.created'
-        event_accumulator = self.bus.accumulator(routing_key)
+        headers = {'name': 'chatd_user_room_created'}
+        event_accumulator = self.bus.accumulator(headers=headers)
 
         room = self.chatd.rooms.create_from_user(room_args)
 
@@ -146,58 +141,49 @@ class TestUserRoom(APIIntegrationTest):
                 ),
             ),
         )
-        required_acl_fmt = 'events.chatd.users.{user_uuid}.rooms.created'
-        event = event_accumulator.accumulate()
-        if add_third_user:
-            assert_that(
-                event,
-                contains_inanyorder(
-                    has_entries(
-                        data=has_entries(room_args),
-                        required_acl=required_acl_fmt.format(
-                            user_uuid=TOKEN_USER_UUID,
-                        ),
-                    ),
-                    has_entries(
-                        data=has_entries(room_args),
-                        required_acl=required_acl_fmt.format(
-                            user_uuid=UUID,
-                        ),
-                    ),
-                    has_entries(
-                        data=has_entries(room_args),
-                        required_acl=required_acl_fmt.format(
-                            user_uuid=UUID_2,
-                        ),
-                    ),
-                ),
-            )
-        else:
-            assert_that(
-                event,
-                contains_inanyorder(
-                    has_entries(
-                        data=has_entries(room_args),
-                        required_acl=required_acl_fmt.format(
-                            user_uuid=TOKEN_USER_UUID,
-                        ),
-                    ),
-                    has_entries(
-                        data=has_entries(room_args),
-                        required_acl=required_acl_fmt.format(
-                            user_uuid=UUID,
-                        ),
-                    ),
-                ),
-            )
-
         self._delete_room(room)
 
-    def test_create(self):
-        self._create_rooms('test-room', False)
+    def test_create_with_many_users(self):
+        room_args = {
+            'name': 'test-group-room',
+            'users': [
+                {
+                    'uuid': str(TOKEN_USER_UUID),
+                    'tenant_uuid': str(TOKEN_TENANT_UUID),
+                    'wazo_uuid': str(WAZO_UUID),
+                },
+                {'uuid': UUID, 'tenant_uuid': UUID, 'wazo_uuid': UUID},
+                {'uuid': UUID_2, 'tenant_uuid': UUID_2, 'wazo_uuid': UUID_2},
+            ],
+        }
+        headers = {'name': 'chatd_user_room_created'}
+        event_accumulator = self.bus.accumulator(headers=headers)
 
-    def test_create_group(self):
-        self._create_rooms('test-room-group', True)
+        room = self.chatd.rooms.create_from_user(room_args)
+
+        assert_that(
+            room,
+            has_entries(
+                uuid=uuid_(),
+                name=room_args['name'],
+                users=contains_inanyorder(*room_args['users']),
+            ),
+        )
+
+        event = event_accumulator.accumulate(with_headers=True)
+        expected_entries = [
+            has_entries(
+                message=has_entries(
+                    data=has_entries(room_args),
+                    required_acl=f'events.chatd.users.{uuid}.rooms.created',
+                ),
+                headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
+            )
+            for uuid in (TOKEN_USER_UUID, UUID, UUID_2)
+        ]
+        assert_that(event, contains_inanyorder(*expected_entries))
+
+        self._delete_room(room)
 
     def test_create_minimal_parameters(self):
         room_args = {'users': [{'uuid': UUID}]}
@@ -247,19 +233,21 @@ class TestUserRoom(APIIntegrationTest):
         self._session.commit()
 
     def test_create_with_wrong_users_number(self):
+        # 100 + current user = 101
         room_args = {
             'users': [
-                # Current user is automatically added to the users list
-                # {
-                #   'uuid': str(TOKEN_USER_UUID),
-                #   'tenant_uuid': str(TOKEN_TENANT_UUID),
-                #   'wazo_uuid': str(WAZO_UUID),
-                # },
-                {'uuid': UUID, 'tenant_uuid': UUID, 'wazo_uuid': UUID},
-                {'uuid': UUID_2, 'tenant_uuid': UUID_2, 'wazo_uuid': UUID_2},
+                {
+                    'uuid': str(TOKEN_USER_UUID),
+                    'tenant_uuid': str(TOKEN_TENANT_UUID),
+                    'wazo_uuid': str(WAZO_UUID),
+                },
             ]
+            + self._generate_users(100)
         }
-        self._add_user_range(room_args)
+        self._assert_create_raise_400_users_error(room_args)
+
+        # 100 without current user = 101
+        room_args = {'users': self._generate_users(100)}
         self._assert_create_raise_400_users_error(room_args)
 
         room_args = {'users': []}
@@ -268,17 +256,15 @@ class TestUserRoom(APIIntegrationTest):
         room_args = {}
         self._assert_create_raise_400_users_error(room_args)
 
-    def _add_user_range(self, room_args):
-        for _ in range(3, 101):
-            room_args['users'].append(
-                {
-                    'uuid': str(uuid.uuid4()),
-                    'tenant_uuid': str(uuid.uuid4()),
-                    'wazo_uuid': str(uuid.uuid4()),
-                }
-            )
-
-        return room_args
+    def _generate_users(self, number):
+        return [
+            {
+                'uuid': str(uuid.uuid4()),
+                'tenant_uuid': str(uuid.uuid4()),
+                'wazo_uuid': str(uuid.uuid4()),
+            }
+            for _ in range(number)
+        ]
 
     def _assert_create_raise_400_users_error(self, room):
         assert_that(

--- a/integration_tests/suite/test_user_room.py
+++ b/integration_tests/suite/test_user_room.py
@@ -34,6 +34,7 @@ UUID_2 = str(uuid.uuid4())
 
 USER_1 = {'uuid': str(uuid.uuid4())}
 USER_2 = {'uuid': str(uuid.uuid4())}
+USER_3 = {'uuid': str(uuid.uuid4())}
 
 
 @use_asset('base')
@@ -61,15 +62,19 @@ class TestUserRoom(APIIntegrationTest):
 
     @fixtures.http.room(users=[USER_1])
     @fixtures.http.room(users=[USER_2])
-    def test_list_by_user_uuid(self, room_1, _):
+    @fixtures.http.room(users=[USER_1, USER_2])
+    def test_list_by_user_uuid(self, room_1, room_2, room_3):
         user_uuids = [USER_1['uuid']]
         rooms = self.chatd.rooms.list_from_user(user_uuids=user_uuids)
         assert_that(
             rooms,
             has_entries(
-                items=contains_inanyorder(has_entries(uuid=room_1['uuid'])),
-                total=equal_to(1),
-                filtered=equal_to(1),
+                items=contains_inanyorder(
+                    has_entries(uuid=room_1['uuid']),
+                    has_entries(uuid=room_3['uuid']),
+                ),
+                total=equal_to(2),
+                filtered=equal_to(2),
             ),
         )
 
@@ -78,13 +83,29 @@ class TestUserRoom(APIIntegrationTest):
         assert_that(
             rooms,
             has_entries(
-                items=contains_inanyorder(has_entries(uuid=room_1['uuid'])),
+                items=contains_inanyorder(
+                    has_entries(uuid=room_1['uuid']),
+                    has_entries(uuid=room_3['uuid']),
+                ),
+                total=equal_to(2),
+                filtered=equal_to(2),
+            ),
+        )
+
+        user_uuids = [str(TOKEN_USER_UUID), USER_1['uuid'], USER_2['uuid']]
+        rooms = self.chatd.rooms.list_from_user(user_uuids=user_uuids)
+        assert_that(
+            rooms,
+            has_entries(
+                items=contains_inanyorder(
+                    has_entries(uuid=room_3['uuid']),
+                ),
                 total=equal_to(1),
                 filtered=equal_to(1),
             ),
         )
 
-        user_uuids = [str(TOKEN_USER_UUID), USER_1['uuid'], USER_2['uuid']]
+        user_uuids = [str(TOKEN_USER_UUID), USER_1['uuid'], USER_3['uuid']]
         rooms = self.chatd.rooms.list_from_user(user_uuids=user_uuids)
         assert_that(
             rooms,

--- a/wazo_chatd/plugins/rooms/api.yml
+++ b/wazo_chatd/plugins/rooms/api.yml
@@ -141,7 +141,7 @@ definitions:
             description: The name of the room
           users:
             type: array
-            description: Only one user can be added for now
+            maxItems: 100
             items:
               $ref: '#/definitions/RoomUser'
         required:

--- a/wazo_chatd/plugins/rooms/http.py
+++ b/wazo_chatd/plugins/rooms/http.py
@@ -36,7 +36,7 @@ class UserRoomListResource(AuthResource):
             self._add_current_user(room_args, token.user_uuid)
 
         try:
-            Length(equal=2)(room_args['users'])
+            Length(min=2, max=100)(room_args['users'])
         except ValidationError as error:
             raise ValidationError({'users': error.messages})
 


### PR DESCRIPTION
change the limitation of UserRoom Length from equal=2 to min=2,max=100,
add test_create_group test,
change test_create_with_wrong_users_number to pass the new validation rule,
change the _assert_create_raise_400_users_error to check the constraint rule