### PR TITLE
WAZO-2499 Adds tenant_uuid to bus event headers

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -12,13 +12,13 @@ class BusClient(bus_helper.BusClient):
     def send_tenant_created_event(self, tenant_uuid):
         self.publish(
             {'data': {'uuid': str(tenant_uuid)}, 'name': 'auth_tenant_added'},
-            f'auth.tenants.{tenant_uuid}.created',
+            routing_key=f'auth.tenants.{tenant_uuid}.created',
         )
 
     def send_tenant_deleted_event(self, tenant_uuid):
         self.publish(
             {'data': {'uuid': str(tenant_uuid)}, 'name': 'auth_tenant_deleted'},
-            f'auth.tenants.{tenant_uuid}.deleted',
+            routing_key=f'auth.tenants.{tenant_uuid}.deleted',
         )
 
     def send_user_created_event(self, user_uuid, tenant_uuid):
@@ -27,7 +27,8 @@ class BusClient(bus_helper.BusClient):
                 'data': {'uuid': str(user_uuid), 'tenant_uuid': str(tenant_uuid)},
                 'name': 'user_created',
             },
-            'config.user.created',
+            routing_key='config.user.created',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_user_deleted_event(self, user_uuid, tenant_uuid):
@@ -36,7 +37,8 @@ class BusClient(bus_helper.BusClient):
                 'data': {'uuid': str(user_uuid), 'tenant_uuid': str(tenant_uuid)},
                 'name': 'user_deleted',
             },
-            'config.user.deleted',
+            routing_key='config.user.deleted',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_session_created_event(
@@ -52,7 +54,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'auth_session_created',
             },
-            f'auth.sessions.{session_uuid}.created',
+            routing_key=f'auth.sessions.{session_uuid}.created',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_session_deleted_event(self, session_uuid, user_uuid, tenant_uuid):
@@ -65,7 +68,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'auth_session_deleted',
             },
-            f'auth.sessions.{session_uuid}.deleted',
+            routing_key=f'auth.sessions.{session_uuid}.deleted',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_refresh_token_created_event(
@@ -81,7 +85,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'auth_refresh_token_created',
             },
-            f'auth.users.{user_uuid}.tokens.{client_id}.created',
+            routing_key=f'auth.users.{user_uuid}.tokens.{client_id}.created',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_refresh_token_deleted_event(self, client_id, user_uuid, tenant_uuid):
@@ -94,7 +99,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'auth_refresh_token_deleted',
             },
-            f'auth.users.{user_uuid}.tokens.{client_id}.deleted',
+            routing_key=f'auth.users.{user_uuid}.tokens.{client_id}.deleted',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_user_line_associated_event(
@@ -114,7 +120,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'user_line_associated',
             },
-            f'config.users.{user_uuid}.lines.{line_id}.updated',
+            routing_key=f'config.users.{user_uuid}.lines.{line_id}.updated',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_line_dissociated_event(self, line_id, user_uuid, tenant_uuid):
@@ -132,7 +139,8 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'user_line_dissociated',
             },
-            f'config.users.{user_uuid}.lines.{line_id}.deleted',
+            routing_key=f'config.users.{user_uuid}.lines.{line_id}.deleted',
+            headers={'tenant_uuid': str(tenant_uuid)},
         )
 
     def send_device_state_changed_event(self, device_name, device_state):
@@ -141,7 +149,7 @@ class BusClient(bus_helper.BusClient):
                 'data': {'State': device_state, 'Device': device_name},
                 'name': 'DeviceStateChange',
             },
-            'ami.DeviceStateChange',
+            routing_key='ami.DeviceStateChange',
         )
 
     def send_new_channel_event(self, channel_name):
@@ -150,7 +158,7 @@ class BusClient(bus_helper.BusClient):
                 'data': {'Channel': channel_name, 'ChannelStateDesc': 'Ring'},
                 'name': 'Newchannel',
             },
-            'ami.Newchannel',
+            routing_key='ami.Newchannel',
         )
 
     def send_new_state_event(self, channel_name, state='undefined'):
@@ -159,19 +167,19 @@ class BusClient(bus_helper.BusClient):
                 'data': {'Channel': channel_name, 'ChannelStateDesc': state},
                 'name': 'Newstate',
             },
-            'ami.Newstate',
+            routing_key='ami.Newstate',
         )
 
     def send_hangup_event(self, channel_name):
         self.publish(
             {'data': {'Channel': channel_name}, 'name': 'Hangup'},
-            'ami.Hangup',
+            routing_key='ami.Hangup',
         )
 
     def send_hold_event(self, channel_name):
         self.publish(
             {'data': {'Channel': channel_name}, 'name': 'Hold'},
-            'ami.Hold',
+            routing_key='ami.Hold',
         )
 
     def send_unhold_event(self, channel_name):
@@ -180,7 +188,7 @@ class BusClient(bus_helper.BusClient):
                 'data': {'Channel': channel_name, 'ChannelStateDesc': 'Up'},
                 'name': 'Unhold',
             },
-            'ami.Hold',
+            routing_key='ami.Hold',
         )
 
     def send_dnd_event(self, user_uuid, tenant_uuid, status):
@@ -193,5 +201,5 @@ class BusClient(bus_helper.BusClient):
                 },
                 'name': 'users_services_dnd_updated',
             },
-            f'config.users.{user_uuid}.services.dnd.updated',
+            routing_key=f'config.users.{user_uuid}.services.dnd.updated',
         )

--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -12,12 +12,13 @@ from hamcrest import (
     has_properties,
     has_items,
     not_,
+    has_entry,
 )
 from wazo_test_helpers import until
 
 from wazo_chatd.database import models
 from .helpers import fixtures
-from .helpers.base import APIIntegrationTest, use_asset
+from .helpers.base import TOKEN_TENANT_UUID, APIIntegrationTest, use_asset
 
 USER_UUID_1 = uuid.uuid4()
 LINE_ID = 42
@@ -100,8 +101,16 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(session_created, tries=3)
 
-        event = event_accumulator.accumulate()
-        assert_that(event, contains(has_entries(data=has_entries(connected=True))))
+        event = event_accumulator.accumulate(with_headers=True)
+        assert_that(
+            event,
+            contains(
+                has_entries(
+                    message=has_entries(data=has_entries(connected=True)),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
+            ),
+        )
 
     @fixtures.db.user(uuid=USER_UUID_1)
     @fixtures.db.session(user_uuid=USER_UUID_1)
@@ -122,8 +131,16 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(session_deleted, tries=3)
 
-        event = event_accumulator.accumulate()
-        assert_that(event, contains(has_entries(data=has_entries(connected=False))))
+        event = event_accumulator.accumulate(with_headers=True)
+        assert_that(
+            event,
+            contains(
+                has_entries(
+                    message=has_entries(data=has_entries(connected=False)),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
+            ),
+        )
 
     @fixtures.db.user()
     def test_refresh_token_created(self, user):
@@ -145,10 +162,15 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(refresh_token_created, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
-            contains(has_entries(data=has_entries(mobile=True))),
+            contains(
+                has_entries(
+                    message=has_entries(data=has_entries(mobile=True)),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
+            ),
         )
 
     @fixtures.db.user(uuid=USER_UUID_1)
@@ -174,8 +196,16 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(refresh_token_deleted, tries=3)
 
-        event = event_accumulator.accumulate()
-        assert_that(event, contains(has_entries(data=has_entries(mobile=False))))
+        event = event_accumulator.accumulate(with_headers=True)
+        assert_that(
+            event,
+            contains(
+                has_entries(
+                    message=has_entries(data=has_entries(mobile=False)),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
+            ),
+        )
 
     @fixtures.db.user()
     def test_user_line_associated(self, user):
@@ -204,14 +234,17 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(user_line_associated, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=line_id, state='unavailable'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=line_id, state='unavailable'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -297,8 +330,16 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(user_line_dissociated, tries=3)
 
-        event = event_accumulator.accumulate()
-        assert_that(event, contains(has_entries(data=has_entries(lines=empty()))))
+        event = event_accumulator.accumulate(with_headers=True)
+        assert_that(
+            event,
+            contains(
+                has_entries(
+                    message=has_entries(data=has_entries(lines=empty())),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
+            ),
+        )
 
     @fixtures.db.endpoint(name=ENDPOINT_NAME, state='unavailable')
     @fixtures.db.user(uuid=USER_UUID_1)
@@ -320,14 +361,17 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(endpoint_state_changed, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=line_id, state='available'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=line_id, state='available'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -367,14 +411,17 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(channel_created, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=line_id, state='progressing'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=line_id, state='progressing'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -393,21 +440,21 @@ class TestEventHandler(APIIntegrationTest):
         def channel_deleted():
             self._session.expire_all()
             result = self._session.query(models.Channel).all()
-            assert_that(
-                result,
-                not_(has_items(has_properties(name=channel_name))),
-            )
+            assert_that(result, not_(has_items(has_properties(name=channel_name))))
 
         until.assert_(channel_deleted, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=LINE_ID, state='available'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=LINE_ID, state='available'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -427,20 +474,22 @@ class TestEventHandler(APIIntegrationTest):
             self._session.expire_all()
             result = self._session.query(models.Channel).all()
             assert_that(
-                result,
-                has_items(has_properties(name=channel_name, state='talking')),
+                result, has_items(has_properties(name=channel_name, state='talking'))
             )
 
         until.assert_(channel_updated, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=LINE_ID, state='talking'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=LINE_ID, state='talking'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -460,20 +509,22 @@ class TestEventHandler(APIIntegrationTest):
             self._session.expire_all()
             result = self._session.query(models.Channel).all()
             assert_that(
-                result,
-                has_items(has_properties(name=channel_name, state='holding')),
+                result, has_items(has_properties(name=channel_name, state='holding'))
             )
 
         until.assert_(channel_held, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=LINE_ID, state='holding'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=LINE_ID, state='holding'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -493,20 +544,22 @@ class TestEventHandler(APIIntegrationTest):
             self._session.expire_all()
             result = self._session.query(models.Channel).all()
             assert_that(
-                result,
-                has_items(has_properties(name=channel_name, state='talking')),
+                result, has_items(has_properties(name=channel_name, state='talking'))
             )
 
         until.assert_(channel_unheld, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
                 has_entries(
-                    data=has_entries(
-                        lines=contains(has_entries(id=LINE_ID, state='talking'))
-                    )
+                    message=has_entries(
+                        data=has_entries(
+                            lines=contains(has_entries(id=LINE_ID, state='talking'))
+                        )
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -528,10 +581,15 @@ class TestEventHandler(APIIntegrationTest):
 
         until.assert_(dnd_updated, tries=3)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains(
-                has_entries(data=has_entries(uuid=user_uuid, do_not_disturb=True))
+                has_entries(
+                    message=has_entries(
+                        data=has_entries(uuid=user_uuid, do_not_disturb=True)
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                )
             ),
         )

--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -12,7 +12,6 @@ from hamcrest import (
     has_properties,
     has_items,
     not_,
-    has_entry,
 )
 from wazo_test_helpers import until
 
@@ -107,7 +106,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     message=has_entries(data=has_entries(connected=True)),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -137,7 +136,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     message=has_entries(data=has_entries(connected=False)),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -168,7 +167,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     message=has_entries(data=has_entries(mobile=True)),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -202,7 +201,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     message=has_entries(data=has_entries(mobile=False)),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -244,7 +243,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=line_id, state='unavailable'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -336,7 +335,7 @@ class TestEventHandler(APIIntegrationTest):
             contains(
                 has_entries(
                     message=has_entries(data=has_entries(lines=empty())),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -371,7 +370,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=line_id, state='available'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -421,7 +420,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=line_id, state='progressing'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -454,7 +453,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=LINE_ID, state='available'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -489,7 +488,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=LINE_ID, state='talking'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -524,7 +523,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=LINE_ID, state='holding'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -559,7 +558,7 @@ class TestEventHandler(APIIntegrationTest):
                             lines=contains(has_entries(id=LINE_ID, state='talking'))
                         )
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )
@@ -589,7 +588,7 @@ class TestEventHandler(APIIntegrationTest):
                     message=has_entries(
                         data=has_entries(uuid=user_uuid, do_not_disturb=True)
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 )
             ),
         )

--- a/integration_tests/suite/test_presences.py
+++ b/integration_tests/suite/test_presences.py
@@ -15,7 +15,6 @@ from hamcrest import (
     is_not,
     none,
     not_,
-    has_key,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -266,7 +265,7 @@ class TestPresence(APIIntegrationTest):
                     message=has_entries(
                         data=has_entries(last_activity=not_(none()), **user_args)
                     ),
-                    headers=has_key('tenant_uuid'),
+                    headers=has_entries(tenant_uuid=str(user.tenant_uuid)),
                 )
             ),
         )

--- a/integration_tests/suite/test_room_message.py
+++ b/integration_tests/suite/test_room_message.py
@@ -157,7 +157,6 @@ class TestUserRoom(APIIntegrationTest):
         message = self.chatd.rooms.create_message_from_user(room['uuid'], message_args)
 
         event = event_accumulator.accumulate(with_headers=True)
-        print(event)
         required_acl_fmt = (
             'events.chatd.users.{user_uuid}.rooms.{room_uuid}.messages.created'
         )

--- a/integration_tests/suite/test_room_message.py
+++ b/integration_tests/suite/test_room_message.py
@@ -14,7 +14,6 @@ from hamcrest import (
     has_properties,
     none,
     is_not,
-    has_entry,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -174,7 +173,7 @@ class TestUserRoom(APIIntegrationTest):
                             user_uuid=user_uuid_1, room_uuid=room['uuid']
                         ),
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 ),
                 has_entries(
                     message=has_entries(
@@ -183,7 +182,7 @@ class TestUserRoom(APIIntegrationTest):
                             user_uuid=user_uuid_2, room_uuid=room['uuid']
                         ),
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 ),
             ),
         )

--- a/integration_tests/suite/test_room_message.py
+++ b/integration_tests/suite/test_room_message.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -14,6 +14,7 @@ from hamcrest import (
     has_properties,
     none,
     is_not,
+    has_entry,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -156,7 +157,8 @@ class TestUserRoom(APIIntegrationTest):
 
         message = self.chatd.rooms.create_message_from_user(room['uuid'], message_args)
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
+        print(event)
         required_acl_fmt = (
             'events.chatd.users.{user_uuid}.rooms.{room_uuid}.messages.created'
         )
@@ -166,16 +168,22 @@ class TestUserRoom(APIIntegrationTest):
             event,
             contains_inanyorder(
                 has_entries(
-                    data=has_entries(**message),
-                    required_acl=required_acl_fmt.format(
-                        user_uuid=user_uuid_1, room_uuid=room['uuid']
+                    message=has_entries(
+                        data=has_entries(**message),
+                        required_acl=required_acl_fmt.format(
+                            user_uuid=user_uuid_1, room_uuid=room['uuid']
+                        ),
                     ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 ),
                 has_entries(
-                    data=has_entries(**message),
-                    required_acl=required_acl_fmt.format(
-                        user_uuid=user_uuid_2, room_uuid=room['uuid']
+                    message=has_entries(
+                        data=has_entries(**message),
+                        required_acl=required_acl_fmt.format(
+                            user_uuid=user_uuid_2, room_uuid=room['uuid']
+                        ),
                     ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 ),
             ),
         )

--- a/integration_tests/suite/test_user_room.py
+++ b/integration_tests/suite/test_user_room.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -11,6 +11,7 @@ from hamcrest import (
     has_entries,
     has_properties,
     none,
+    has_entry,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -81,17 +82,23 @@ class TestUserRoom(APIIntegrationTest):
             ),
         )
 
-        event = event_accumulator.accumulate()
+        event = event_accumulator.accumulate(with_headers=True)
         assert_that(
             event,
             contains_inanyorder(
                 has_entries(
-                    data=has_entries(room_args),
-                    required_acl=f'events.chatd.users.{TOKEN_USER_UUID}.rooms.created',
+                    message=has_entries(
+                        data=has_entries(room_args),
+                        required_acl=f'events.chatd.users.{TOKEN_USER_UUID}.rooms.created',
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 ),
                 has_entries(
-                    data=has_entries(room_args),
-                    required_acl=f'events.chatd.users.{UUID}.rooms.created',
+                    message=has_entries(
+                        data=has_entries(room_args),
+                        required_acl=f'events.chatd.users.{UUID}.rooms.created',
+                    ),
+                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
                 ),
             ),
         )

--- a/integration_tests/suite/test_user_room.py
+++ b/integration_tests/suite/test_user_room.py
@@ -11,7 +11,6 @@ from hamcrest import (
     has_entries,
     has_properties,
     none,
-    has_entry,
 )
 
 from wazo_test_helpers.hamcrest.raises import raises
@@ -91,14 +90,14 @@ class TestUserRoom(APIIntegrationTest):
                         data=has_entries(room_args),
                         required_acl=f'events.chatd.users.{TOKEN_USER_UUID}.rooms.created',
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 ),
                 has_entries(
                     message=has_entries(
                         data=has_entries(room_args),
                         required_acl=f'events.chatd.users.{UUID}.rooms.created',
                     ),
-                    headers=has_entry('tenant_uuid', str(TOKEN_TENANT_UUID)),
+                    headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 ),
             ),
         )

--- a/wazo_chatd/plugins/presences/notifier.py
+++ b/wazo_chatd/plugins/presences/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_bus.resources.chatd.events import PresenceUpdatedEvent
@@ -11,6 +11,8 @@ class PresenceNotifier:
         self._bus = bus
 
     def updated(self, user):
+        headers = {}
         user_json = UserPresenceSchema().dump(user)
         event = PresenceUpdatedEvent(user_json)
-        self._bus.publish(event)
+        headers['tenant_uuid'] = user_json['tenant_uuid']
+        self._bus.publish(event, headers=headers)

--- a/wazo_chatd/plugins/rooms/notifier.py
+++ b/wazo_chatd/plugins/rooms/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo_bus.resources.chatd.events import (
@@ -15,16 +15,26 @@ class RoomNotifier:
 
     def created(self, room):
         room_json = RoomSchema().dump(room)
+        tenant_uuid = room_json['tenant_uuid']
         for user in room_json['users']:
             event = UserRoomCreatedEvent(user['uuid'], room_json)
             self._bus.publish(
-                event, headers={'user_uuid:{uuid}'.format(uuid=user['uuid']): True}
+                event,
+                headers={
+                    'user_uuid:{uuid}'.format(uuid=user['uuid']): True,
+                    'tenant_uuid': tenant_uuid,
+                },
             )
 
     def message_created(self, room, message):
         message_json = MessageSchema().dump(message)
+        tenant_uuid = message_json['tenant_uuid']
         for user in room.users:
             event = UserRoomMessageCreatedEvent(user.uuid, room.uuid, message_json)
             self._bus.publish(
-                event, headers={'user_uuid:{uuid}'.format(uuid=user.uuid): True}
+                event,
+                headers={
+                    'user_uuid:{uuid}'.format(uuid=user.uuid): True,
+                    'tenant_uuid': tenant_uuid,
+                },
             )


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-test-helpers/pull/69

The idea is to inject tenant_uuid in all bus events, so that messages can be filtered by tenant when exiting the stack to external apis
