### PR TITLE
[WAZO-2709] Inject token renewer for modules

### DIFF
--- a/wazo_chatd/controller.py
+++ b/wazo_chatd/controller.py
@@ -53,6 +53,8 @@ class Controller:
                 'bus_publisher': self.bus_publisher,
                 'status_aggregator': self.status_aggregator,
                 'thread_manager': self.thread_manager,
+                'token_changed_subscribe': self.token_renewer.subscribe_to_token_change,
+                'next_token_changed_subscribe': self.token_renewer.subscribe_to_next_token_change,
             },
         )
 


### PR DESCRIPTION
Reason: Our other services have this injection, and it's very useful for creating modules who need to have access to other services with our python clients.