### PR TITLE
Pull request for WAZO-2760-api-datetime-with-timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 22.07
+
+* The following fields now include a timezone indication:
+
+  * `created_at` for the following endpoints:
+    * `GET /users​/me​/rooms​/messages`
+    * `GET ​/users​/me​/rooms​/{room_uuid}​/messages`
+    * `POST ​/users​/me​/rooms​/{room_uuid}​/messages`
+  * `last_activity` for the following endpoints:
+    * `GET ​/users​/presences`
+    * `GET ​/users​/{user_uuid}​/presences`
+
 ## 21.12
 
 * New read only parameters have been added to the `/status` API:

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -51,7 +51,7 @@ def run_migrations_offline():
     script output.
 
     """
-    url = URI or get_url() or config.get_main_option("sqlalchemy.url")
+    url = URI or config.get_main_option("sqlalchemy.url") or get_url()
     context.configure(url=url, version_table=VERSION_TABLE)
 
     with context.begin_transaction():
@@ -65,7 +65,7 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    url = URI or get_url() or config.get_main_option("sqlalchemy.url")
+    url = URI or config.get_main_option("sqlalchemy.url") or get_url()
     engine = create_engine(url)
 
     connection = engine.connect()

--- a/alembic/versions/d39356de87a3_database_add_timezone_to_dates.py
+++ b/alembic/versions/d39356de87a3_database_add_timezone_to_dates.py
@@ -1,0 +1,69 @@
+"""database: add timezone to dates
+
+Revision ID: d39356de87a3
+Revises: 777e588c50f3
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'd39356de87a3'
+down_revision = '777e588c50f3'
+
+
+def add_timezone_from_utc(table_name, column_name):
+    intermediary_column = column_name + '_without_timezone'
+    op.alter_column(
+        table_name,
+        column_name,
+        new_column_name=intermediary_column,
+    )
+    op.add_column(
+        table_name,
+        sa.Column(column_name, sa.DateTime(timezone=True)),
+    )
+    op.execute(
+        f"UPDATE {table_name} SET {column_name} = {intermediary_column} at time zone 'utc'"
+    )
+    op.drop_column(table_name, intermediary_column)
+
+
+def remove_timezone_at_utc(table_name, column_name):
+    intermediary_column = column_name + '_with_timezone'
+    op.alter_column(
+        table_name,
+        column_name,
+        new_column_name=intermediary_column,
+    )
+    op.add_column(
+        table_name,
+        sa.Column(column_name, sa.DateTime()),
+    )
+    op.execute(
+        f"UPDATE {table_name} SET {column_name} = {intermediary_column} at time zone 'utc'"
+    )
+    op.drop_column(table_name, intermediary_column)
+
+
+def upgrade():
+    add_timezone_from_utc('chatd_user', 'last_activity')
+
+    add_timezone_from_utc('chatd_room_message', 'created_at')
+    op.alter_column(
+        'chatd_room_message',
+        'created_at',
+        nullable=False,
+    )
+
+
+def downgrade():
+    remove_timezone_at_utc('chatd_user', 'last_activity')
+
+    remove_timezone_at_utc('chatd_room_message', 'created_at')
+    op.alter_column(
+        'chatd_room_message',
+        'created_at',
+        nullable=False,
+    )

--- a/integration_tests/suite/test_db_user.py
+++ b/integration_tests/suite/test_db_user.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import datetime
@@ -38,7 +38,7 @@ USER_UUID = uuid.uuid4()
 class TestUser(DBIntegrationTest):
     def test_create(self):
         user_uuid = uuid.uuid4()
-        last_activity = datetime.datetime.now()
+        last_activity = datetime.datetime.now(datetime.timezone.utc)
         user = User(
             uuid=user_uuid,
             tenant_uuid=TENANT_1,
@@ -133,7 +133,7 @@ class TestUser(DBIntegrationTest):
         user_uuid = user.uuid
         user_state = 'invisible'
         user_status = 'other status'
-        user_last_activity = datetime.datetime.now()
+        user_last_activity = datetime.datetime.now(datetime.timezone.utc)
         user_do_not_disturb = True
 
         user.state = user_state

--- a/wazo_chatd/database/models.py
+++ b/wazo_chatd/database/models.py
@@ -1,7 +1,7 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import (
     Boolean,
@@ -48,7 +48,7 @@ class User(Base):
     )
     status = Column(Text())
     do_not_disturb = Column(Boolean(), nullable=False, server_default='false')
-    last_activity = Column(DateTime())
+    last_activity = Column(DateTime(timezone=True))
 
     tenant = relationship('Tenant')
     sessions = relationship(
@@ -209,6 +209,11 @@ class RoomMessage(Base):
     user_uuid = Column(UUIDType(), nullable=False)
     tenant_uuid = Column(UUIDType(), nullable=False)
     wazo_uuid = Column(UUIDType(), nullable=False)
-    created_at = Column(DateTime(), default=datetime.datetime.utcnow, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("(now() at time zone 'utc')"),
+        nullable=False,
+    )
 
     room = relationship('Room', viewonly=True)


### PR DESCRIPTION
## alembic: allow overriding database URL with a config file

Why:

* Easer to test upgrades on a remote machine

## database: add timezones to timestamps

Why:

* So that API consumer do not need to worry about timezone