### PR TITLE
test: use mock from unittest library

### DIFF
--- a/integration_tests/suite/test_db_presence_initiator.py
+++ b/integration_tests/suite/test_db_presence_initiator.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
 
-from mock import Mock
+from unittest.mock import Mock
 from hamcrest import assert_that, equal_to, has_properties
 
 from .helpers import fixtures

--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -1,4 +1,3 @@
-mock
 kombu
 openapi-spec-validator
 pyhamcrest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/wazo_chatd/plugins/presences/tests/test_schemas.py
+++ b/wazo_chatd/plugins/presences/tests/test_schemas.py
@@ -1,10 +1,10 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
 import unittest
 
-from mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock
 from marshmallow.exceptions import ValidationError
 
 from hamcrest import (

--- a/wazo_chatd/tests/test_controller.py
+++ b/wazo_chatd/tests/test_controller.py
@@ -1,8 +1,8 @@
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 
 from ..controller import _sigterm_handler
 


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package