### PR TITLE
Pull request for fix-generated-project-name

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -80,26 +80,6 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
         cls.wait_strategy.wait(cls)
 
     @classmethod
-    def start_auth_service(cls):
-        cls.start_service('auth')
-        cls.auth = cls.make_auth()
-        until.true(cls.auth.is_up, tries=5)
-        cls.create_token()
-
-    @classmethod
-    def stop_auth_service(cls):
-        cls.stop_service('auth')
-
-    @classmethod
-    def start_chatd_service(cls):
-        cls.start_service('chatd')
-        cls.chatd = cls.make_chatd()
-
-    @classmethod
-    def stop_chatd_service(cls):
-        cls.stop_service('chatd')
-
-    @classmethod
     def create_token(cls):
         if isinstance(cls.auth, WrongClient):
             return
@@ -186,6 +166,31 @@ class _BaseAssetLaunchingTestCase(AssetLaunchingTestCase):
         bus.downstream_exchange_declare('wazo-headers', 'headers')
         return bus
 
+    @classmethod
+    def start_auth_service(cls):
+        cls.start_service('auth')
+        cls.auth = cls.make_auth()
+        until.true(cls.auth.is_up, tries=5)
+        cls.create_token()
+
+    @classmethod
+    def stop_auth_service(cls):
+        cls.stop_service('auth')
+
+    @classmethod
+    def start_chatd_service(cls):
+        cls.start_service('chatd')
+        cls.chatd = cls.make_chatd()
+
+    @classmethod
+    def stop_chatd_service(cls):
+        cls.stop_service('chatd')
+
+    @classmethod
+    def restart_chatd_service(cls):
+        cls.restart_service('chatd')
+        cls.chatd = cls.make_chatd()
+
 
 class APIAssetLaunchingTestCase(_BaseAssetLaunchingTestCase):
     asset = 'base'
@@ -214,6 +219,56 @@ class _BaseIntegrationTest(unittest.TestCase):
     def _session(self):
         return self._Session()
 
+    @classmethod
+    def reset_clients(cls):
+        cls._Session = cls.asset_cls.make_db_session()
+        cls.amid = cls.asset_cls.make_amid()
+        cls.chatd = cls.asset_cls.make_chatd()
+        cls.auth = cls.asset_cls.make_auth()
+        cls.confd = cls.asset_cls.make_confd()
+        cls.bus = cls.asset_cls.make_bus()
+
+    @classmethod
+    def start_auth_service(cls):
+        cls.asset_cls.start_auth_service()
+        cls.auth = cls.asset_cls.make_auth()
+
+    @classmethod
+    def stop_auth_service(cls):
+        cls.asset_cls.stop_auth_service()
+
+    @classmethod
+    def start_chatd_service(cls):
+        cls.asset_cls.start_chatd_service()
+        cls.chatd = cls.asset_cls.make_chatd()
+
+    @classmethod
+    def stop_chatd_service(cls):
+        cls.asset_cls.stop_chatd_service()
+
+    @classmethod
+    def restart_chatd_service(cls):
+        cls.asset_cls.restart_chatd_service()
+        cls.chatd = cls.asset_cls.make_chatd()
+
+    @classmethod
+    def start_amid_service(cls):
+        cls.asset_cls.start_service('amid')
+        cls.amid = cls.asset_cls.make_amid()
+
+    @classmethod
+    def stop_amid_service(cls):
+        cls.asset_cls.stop_service('amid')
+
+    @classmethod
+    def start_postgres_service(cls):
+        cls.asset_cls.start_service('postgres')
+        cls._Session = cls.asset_cls.make_db_session()
+
+    @classmethod
+    def stop_postgres_service(cls):
+        cls.asset_cls.stop_service('postgres')
+
     def setUp(self):
         super().setUp()
         self._dao = DAO()
@@ -224,15 +279,6 @@ class _BaseIntegrationTest(unittest.TestCase):
     def tearDown(self):
         self._Session.rollback()
         self._Session.remove()
-
-    @classmethod
-    def reset_clients(cls):
-        cls._Session = cls.asset_cls.make_db_session()
-        cls.amid = cls.asset_cls.make_amid()
-        cls.chatd = cls.asset_cls.make_chatd()
-        cls.auth = cls.asset_cls.make_auth()
-        cls.confd = cls.asset_cls.make_confd()
-        cls.bus = cls.asset_cls.make_bus()
 
 
 class DBIntegrationTest(_BaseIntegrationTest):

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -208,7 +208,7 @@ class DBAssetLaunchingTestCase(_BaseAssetLaunchingTestCase):
 class _BaseIntegrationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._Session = DBAssetLaunchingTestCase.make_db_session()
+        cls._Session = cls.asset_cls.make_db_session()
 
     @property
     def _session(self):
@@ -225,21 +225,31 @@ class _BaseIntegrationTest(unittest.TestCase):
         self._Session.rollback()
         self._Session.remove()
 
+    @classmethod
+    def reset_clients(cls):
+        cls._Session = cls.asset_cls.make_db_session()
+        cls.amid = cls.asset_cls.make_amid()
+        cls.chatd = cls.asset_cls.make_chatd()
+        cls.auth = cls.asset_cls.make_auth()
+        cls.confd = cls.asset_cls.make_confd()
+        cls.bus = cls.asset_cls.make_bus()
+
 
 class DBIntegrationTest(_BaseIntegrationTest):
-    pass
+    asset_cls = DBAssetLaunchingTestCase
 
 
 class APIIntegrationTest(_BaseIntegrationTest):
+    asset_cls = APIAssetLaunchingTestCase
+
     @classmethod
     def setUpClass(cls):
         cls.reset_clients()
 
+
+class InitIntegrationTest(_BaseIntegrationTest):
+    asset_cls = InitAssetLaunchingTestCase
+
     @classmethod
-    def reset_clients(cls):
-        cls._Session = APIAssetLaunchingTestCase.make_db_session()
-        cls.amid = APIAssetLaunchingTestCase.make_amid()
-        cls.chatd = APIAssetLaunchingTestCase.make_chatd()
-        cls.auth = APIAssetLaunchingTestCase.make_auth()
-        cls.confd = APIAssetLaunchingTestCase.make_confd()
-        cls.bus = APIAssetLaunchingTestCase.make_bus()
+    def setUpClass(cls):
+        cls.reset_clients()

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -9,7 +9,7 @@ from wazo_test_helpers import until
 
 
 class WaitStrategy:
-    def wait(self, setupd):
+    def wait(self, chatd):
         raise NotImplementedError()
 
 

--- a/integration_tests/suite/test_config.py
+++ b/integration_tests/suite/test_config.py
@@ -9,7 +9,6 @@ from wazo_test_helpers.hamcrest.raises import raises
 from .helpers.base import (
     APIIntegrationTest,
     use_asset,
-    APIAssetLaunchingTestCase,
     TOKEN_SUBTENANT_UUID,
     START_TIMEOUT,
 )
@@ -24,17 +23,16 @@ class TestConfig(APIIntegrationTest):
         assert_that(result, has_key('rest_api'))
 
     def test_restrict_only_master_tenant(self):
-        chatd_client = APIAssetLaunchingTestCase.make_chatd(str(TOKEN_SUBTENANT_UUID))
+        chatd_client = self.asset_cls.make_chatd(str(TOKEN_SUBTENANT_UUID))
         assert_that(
             calling(chatd_client.config.get),
             raises(ChatdError, has_properties('status_code', 401)),
         )
 
     def test_restrict_on_with_slow_wazo_auth(self):
-        APIAssetLaunchingTestCase.stop_chatd_service()
-        APIAssetLaunchingTestCase.stop_auth_service()
-        APIAssetLaunchingTestCase.start_chatd_service()
-        self.reset_clients()
+        self.stop_chatd_service()
+        self.stop_auth_service()
+        self.start_chatd_service()
 
         def _returns_503():
             try:
@@ -46,8 +44,7 @@ class TestConfig(APIIntegrationTest):
 
         until.assert_(_returns_503, timeout=START_TIMEOUT)
 
-        APIAssetLaunchingTestCase.start_auth_service()
-        self.reset_clients()
+        self.start_auth_service()
 
         def _not_return_503():
             try:

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -6,7 +6,7 @@ import requests
 import yaml
 
 from openapi_spec_validator import validate_v2_spec
-from .helpers.base import APIIntegrationTest, APIAssetLaunchingTestCase, use_asset
+from .helpers.base import APIIntegrationTest, use_asset
 
 requests.packages.urllib3.disable_warnings()
 
@@ -17,7 +17,7 @@ logger.setLevel(logging.INFO)
 @use_asset('base')
 class TestDocumentation(APIIntegrationTest):
     def test_documentation_errors(self):
-        port = APIAssetLaunchingTestCase.service_port(9304, 'chatd')
+        port = self.asset_cls.service_port(9304, 'chatd')
         api_url = f'http://127.0.0.1:{port}/1.0/api/api.yml'
         api = requests.get(api_url)
         validate_v2_spec(yaml.safe_load(api.text))

--- a/integration_tests/suite/test_presence_initialization.py
+++ b/integration_tests/suite/test_presence_initialization.py
@@ -24,7 +24,7 @@ from .helpers.wait_strategy import (
     RestApiOkWaitStrategy,
 )
 from .helpers.base import (
-    APIIntegrationTest,
+    InitIntegrationTest,
     InitAssetLaunchingTestCase,
     CHATD_TOKEN_TENANT_UUID,
     use_asset,
@@ -40,7 +40,7 @@ FAKE_UUID_STR = str(uuid.uuid4())
 
 
 @use_asset('initialization')
-class TestPresenceInitialization(APIIntegrationTest):
+class TestPresenceInitialization(InitIntegrationTest):
     @fixtures.db.endpoint()
     @fixtures.db.endpoint(name=ENDPOINT_NAME, state='available')
     @fixtures.db.tenant()
@@ -337,7 +337,7 @@ class TestPresenceInitialization(APIIntegrationTest):
 
 
 @use_asset('initialization')
-class TestPresenceInitializationErrors(APIIntegrationTest):
+class TestPresenceInitializationErrors(InitIntegrationTest):
     def test_server_initialization_do_not_block_on_http_error(self):
         InitAssetLaunchingTestCase.stop_service('chatd')
         InitAssetLaunchingTestCase.stop_service('amid')

--- a/integration_tests/suite/test_presence_initialization.py
+++ b/integration_tests/suite/test_presence_initialization.py
@@ -25,7 +25,6 @@ from .helpers.wait_strategy import (
 )
 from .helpers.base import (
     InitIntegrationTest,
-    InitAssetLaunchingTestCase,
     CHATD_TOKEN_TENANT_UUID,
     use_asset,
 )
@@ -215,8 +214,7 @@ class TestPresenceInitialization(InitIntegrationTest):
         )
 
         # start initialization
-        InitAssetLaunchingTestCase.restart_service('chatd')
-        self.chatd = InitAssetLaunchingTestCase.make_chatd()
+        self.restart_chatd_service()
         PresenceInitOkWaitStrategy().wait(self)
 
         self._session.expire_all()
@@ -339,10 +337,9 @@ class TestPresenceInitialization(InitIntegrationTest):
 @use_asset('initialization')
 class TestPresenceInitializationErrors(InitIntegrationTest):
     def test_server_initialization_do_not_block_on_http_error(self):
-        InitAssetLaunchingTestCase.stop_service('chatd')
-        InitAssetLaunchingTestCase.stop_service('amid')
-        InitAssetLaunchingTestCase.start_service('chatd')
-        self.reset_clients()
+        self.stop_chatd_service()
+        self.stop_amid_service()
+        self.start_chatd_service()
         RestApiOkWaitStrategy().wait(self)
 
         def server_wait():
@@ -359,15 +356,14 @@ class TestPresenceInitializationErrors(InitIntegrationTest):
 
         until.assert_(server_wait, tries=5)
 
-        InitAssetLaunchingTestCase.start_service('amid')
-        self.reset_clients()
+        self.start_amid_service()
 
         PresenceInitOkWaitStrategy().wait(self)
 
     def test_server_initialization_do_not_block_on_database_error(self):
-        InitAssetLaunchingTestCase.stop_service('chatd')
-        InitAssetLaunchingTestCase.stop_service('postgres')
-        InitAssetLaunchingTestCase.start_service('chatd')
+        self.stop_chatd_service()
+        self.stop_postgres_service()
+        self.start_chatd_service()
         self.reset_clients()
         RestApiOkWaitStrategy().wait(self)
 
@@ -385,18 +381,16 @@ class TestPresenceInitializationErrors(InitIntegrationTest):
 
         until.assert_(server_wait, tries=5)
 
-        InitAssetLaunchingTestCase.start_service('postgres')
-        self.reset_clients()
+        self.start_postgres_service()
 
         PresenceInitOkWaitStrategy().wait(self)
 
     @fixtures.db.user()
     def test_api_return_503(self, user):
         user_args = {'uuid': str(user.uuid), 'state': 'available'}
-        InitAssetLaunchingTestCase.stop_service('chatd')
-        InitAssetLaunchingTestCase.stop_service('amid')
-        InitAssetLaunchingTestCase.start_service('chatd')
-        self.reset_clients()
+        self.stop_chatd_service()
+        self.stop_amid_service()
+        self.start_chatd_service()
         RestApiOkWaitStrategy().wait(self)
 
         assert_that(
@@ -420,7 +414,6 @@ class TestPresenceInitializationErrors(InitIntegrationTest):
             ),
         )
 
-        InitAssetLaunchingTestCase.start_service('amid')
-        self.reset_clients()
+        self.start_amid_service()
         PresenceInitOkWaitStrategy().wait(self)
         self.chatd.user_presences.list()


### PR DESCRIPTION
## test: fix copy/paste typo


## test: fix mapping between asset class and base class

why: since docker-compose project base name depends from asset name, we
must have one asset by *IntegrationTest class

## test: refactor helper to start/stop service

why: avoid explicit logic to reset client after restart