### PR TITLE
fix wrong openapi spec for room

### DIFF
--- a/wazo_chatd/plugins/rooms/api.yml
+++ b/wazo_chatd/plugins/rooms/api.yml
@@ -209,11 +209,6 @@ definitions:
         readOnly: true
       room:
         $ref: '#/definitions/RoomRelationBase'
-      message:
-        type: string
-
-    required:
-      - message
 
   Messages:
     title: UserItems


### PR DESCRIPTION
why: message field doesn't exist