### PR TITLE
tests: fix flaky presence init tests

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -272,8 +272,18 @@ class _BaseIntegrationTest(unittest.TestCase):
         cls.asset_cls.start_service('postgres')
         cls._Session = cls.asset_cls.make_db_session()
 
+        def db_is_up():
+            try:
+                cls._Session.execute('SELECT 1')
+            except Exception:
+                return False
+            return True
+
+        until.true(db_is_up, tries=60)
+
     @classmethod
     def stop_postgres_service(cls):
+        cls._Session.remove()
         cls.asset_cls.stop_service('postgres')
 
     def setUp(self):


### PR DESCRIPTION
why: need to remove session before stopping postgres to avoid to leave
DB corrupt and be longer to boot. Moreover, we also need to remove
scoped_session to be able to recreate a valid cls._Session.
We were only lucky that no more test need this helper, because it
wouldn't work

And add small helper to be sure db is up, when it takes longer time to
boot (ex: when DB is corrupted).