### PR TITLE
pin importlib_metadata package

### DIFF
--- a/integration_tests/test-requirements-for-tox.txt
+++ b/integration_tests/test-requirements-for-tox.txt
@@ -1,3 +1,4 @@
+importlib_metadata<5.0.0  # from kombu - https://github.com/celery/kombu/issues/1600
 kombu
 openapi-spec-validator
 pyhamcrest

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ cheroot==6.5.4
 flask-cors==3.0.7
 flask-restful==0.3.7
 flask==1.0.2
+importlib_metadata==1.6.0  # from kombu
 itsdangerous==0.24  # from flask
 jinja2==2.10  # from flask
 kombu==4.6.11


### PR DESCRIPTION
why: kombu use this library without pinning, and the latest version
(5.0.0) of importlib_metadata break the API.
We pin the library to the same version of current (buster) debian version