### PR TITLE
test: dispose connection before stopping postgres

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -283,6 +283,7 @@ class _BaseIntegrationTest(unittest.TestCase):
 
     @classmethod
     def stop_postgres_service(cls):
+        cls._Session.get_bind().dispose()
         cls._Session.remove()
         cls.asset_cls.stop_service('postgres')
 


### PR DESCRIPTION
why: restarting postgres test was failing because postgres was too long
to restart. It was very slow because it was not well closed and the DB
performed a safe check. DB wasn't well closed because a connection was
still alive (idle) and the smart shutdown[1] was not done correctly

Since engine is created with autocommit=False (default value), As
soon we call Session.remove(), another transaction is immediately
begun[2].
To avoid this behavior, we can dispose of the connection pool before and
remove any existing transaction, thus no other transaction could be
created

1. https://www.postgresql.org/docs/current/server-shutdown.html
2. https://docs.sqlalchemy.org/en/12/orm/session_api.html#sqlalchemy.orm.session.Session.close
3. https://docs.sqlalchemy.org/en/12/core/connections.html?highlight=dispose#engine-disposal