### PR TITLE
test: dispose connections on tearDownClass

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -222,6 +222,11 @@ class _BaseIntegrationTest(unittest.TestCase):
     def setUpClass(cls):
         cls._Session = cls.asset_cls.make_db_session()
 
+    @classmethod
+    def tearDownClass(cls):
+        cls._Session.get_bind().dispose()
+        cls._Session.remove()
+
     @property
     def _session(self):
         return self._Session()
@@ -296,7 +301,6 @@ class _BaseIntegrationTest(unittest.TestCase):
 
     def tearDown(self):
         self._Session.rollback()
-        self._Session.remove()
 
 
 class DBIntegrationTest(_BaseIntegrationTest):


### PR DESCRIPTION
why: initialization class is used twice and connection from previous
test are still alive by the test runner and the session registry

For full explanation see previous commit
4dcb209f0f18be36d8a74d1f8591454e58c9af80