### PR TITLE
Pull request for WAZO-2953-regression-get-chat-room

### DIFF
--- a/wazo_chatd/plugins/presences/schemas.py
+++ b/wazo_chatd/plugins/presences/schemas.py
@@ -89,7 +89,7 @@ class UserPresenceSchema(Schema):
 class ListRequestSchema(Schema):
 
     recurse = fields.Boolean(missing=False)
-    user_uuid = fields.List(fields.UUID(), missing=[], attribute='uuids')
+    user_uuid = fields.List(fields.UUID(), missing=list, attribute='uuids')
 
     @pre_load
     def convert_user_uuid_to_list(self, data, **kwargs):

--- a/wazo_chatd/plugins/rooms/schemas.py
+++ b/wazo_chatd/plugins/rooms/schemas.py
@@ -18,7 +18,7 @@ class RoomSchema(Schema):
 
     name = fields.String(allow_none=True)
 
-    users = fields.Nested('RoomUserSchema', many=True, missing=[])
+    users = fields.Nested('RoomUserSchema', many=True, missing=list)
 
 
 class MessageSchema(Schema):

--- a/wazo_chatd/plugins/rooms/schemas.py
+++ b/wazo_chatd/plugins/rooms/schemas.py
@@ -57,7 +57,7 @@ class MessageListRequestSchema(_ListSchema):
 
 
 class RoomListRequestSchema(Schema):
-    user_uuid = fields.List(fields.UUID(), missing=[], attribute='user_uuids')
+    user_uuid = fields.List(fields.UUID(), missing=list, attribute='user_uuids')
 
     @pre_load
     def convert_user_uuid_to_list(self, data, **kwargs):


### PR DESCRIPTION
## room: fix reused object

why: instantiate list in the schema definition will reuse same object
for all requests. Since we update this object in the http.py, it causes
issue. We need to have a new list object at each call

## schemas: do not instantiate missing list

why: avoid side effect when code modify it
note: These objects don't have issue, only to be future proof