### PR TITLE
refresh user's token if we get 401

### DIFF
--- a/wazo_chatd/plugins/teams_presence/services.py
+++ b/wazo_chatd/plugins/teams_presence/services.py
@@ -69,7 +69,7 @@ class TeamsService:
             raise ValueError(f'user `{user_uuid}` is already being synchronized')
 
         self._synchronizers[user_uuid] = synchronizer = SubscriptionRenewer(
-            url, user_config, self.notifier
+            self.auth, url, user_config, self.notifier
         )
         synchronizer.start()
 


### PR DESCRIPTION
Why:

* If we get 401, it means our user token's is expired, When expired, auth will automatically fetch a new access token for us