### PR TITLE
fix tox.ini for tox4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist = py37, pycodestyle, pylint
-skipsdist = true
+skipsdist = false
 
 [testenv]
 basepython = python3.7
@@ -23,7 +23,7 @@ commands =
     -sh -c 'pycodestyle --ignore=E501,W503 wazo_chatd > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:pylint]
@@ -33,11 +33,11 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
     sh
 
 [testenv:integration]
-usedevelop = true
+use_develop = true
 deps = -rintegration_tests/test-requirements-for-tox.txt
 changedir = integration_tests
 passenv =
@@ -46,7 +46,7 @@ passenv =
 commands =
     make test-setup
     pytest -v {posargs}
-whitelist_externals =
+allowlist_externals =
     make
     sh
 


### PR DESCRIPTION
changes:

* skipsdist and usedevelop are now mutually exclusive
* usedevelop -> use_develop for future
* whitelist_externals -> allowlist_externals