### PR TITLE
device state change: ignore hints

### DIFF
--- a/wazo_chatd/plugins/presences/bus_consume.py
+++ b/wazo_chatd/plugins/presences/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -211,6 +211,9 @@ class BusEventHandler:
 
     def _device_state_change(self, event):
         endpoint_name = event['Device']
+        if endpoint_name.startswith('Custom:'):
+            return
+
         state = DEVICE_STATE_MAP.get(event['State'], 'unavailable')
         with session_scope():
             endpoint = self._dao.endpoint.find_or_create(endpoint_name)

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -382,8 +382,12 @@ class Initiator:
                 if event.get('Event') != 'DeviceStateChange':
                     continue
 
+                endpoint_name = event['Device']
+                if endpoint_name.startswith('Custom:'):
+                    continue
+
                 endpoint_args = {
-                    'name': event['Device'],
+                    'name': endpoint_name,
                     'state': DEVICE_STATE_MAP.get(event['State'], 'unavailable'),
                 }
                 logger.debug(

--- a/wazo_chatd/plugins/presences/tests/test_bus_consume.py
+++ b/wazo_chatd/plugins/presences/tests/test_bus_consume.py
@@ -1,0 +1,24 @@
+# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+from ..bus_consume import BusEventHandler
+
+
+class TestBusEventHandler(TestCase):
+    def setUp(self):
+        self.dao = Mock()
+        self.notifier = Mock()
+        self.handler = BusEventHandler(self.dao, self.notifier)
+
+    def test_on_device_state_change_ignored_on_hints(self):
+        event = {
+            'State': 'unavailable',
+            'Device': 'Custom:*7351033***223',
+        }
+
+        self.handler._device_state_change(event)
+
+        self.dao.endpoint.find_or_create.assert_not_called()


### PR DESCRIPTION
we do not need to track hints for chatd to work, at the moment more hints are stored in the db then endpoints. updating the hints also adds pressure on the database that updates their statuses not no reason