### PR TITLE
bus: bind to local events only

### DIFF
--- a/integration_tests/suite/helpers/bus.py
+++ b/integration_tests/suite/helpers/bus.py
@@ -6,6 +6,7 @@ import uuid
 from wazo_test_helpers import bus as bus_helper
 
 FAKE_UUID = str(uuid.uuid4())
+WAZO_UUID = '00000000-0000-0000-0000-0000000c4a7d'
 
 
 class BusClient(bus_helper.BusClient):
@@ -20,6 +21,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_tenant_added',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -34,6 +36,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_tenant_deleted',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -49,6 +52,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'user_created',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -61,6 +65,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'user_deleted',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -80,6 +85,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_session_created',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -96,6 +102,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_session_deleted',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -115,6 +122,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_refresh_token_created',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -131,6 +139,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'auth_refresh_token_deleted',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -157,6 +166,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'user_line_associated',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -181,6 +191,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'user_line_dissociated',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -195,6 +206,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'DeviceStateChange',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -209,6 +221,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'Newchannel',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -223,6 +236,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'Newstate',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -236,6 +250,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'Hangup',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -249,6 +264,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'Hold',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -263,6 +279,7 @@ class BusClient(bus_helper.BusClient):
             },
             headers={
                 'name': 'Unhold',
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -279,6 +296,7 @@ class BusClient(bus_helper.BusClient):
             headers={
                 'name': 'users_services_dnd_updated',
                 'tenant_uuid': str(tenant_uuid),
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -295,6 +313,7 @@ class BusClient(bus_helper.BusClient):
                 'name': 'auth_user_external_auth_added',
                 'tenant_uuid': str(tenant_uuid),
                 f'user_uuid:{user_uuid}': True,
+                'origin_uuid': WAZO_UUID,
             },
         )
 
@@ -311,5 +330,6 @@ class BusClient(bus_helper.BusClient):
                 'name': 'auth_user_external_auth_deleted',
                 'tenant_uuid': str(tenant_uuid),
                 f'user_uuid:{user_uuid}': True,
+                'origin_uuid': WAZO_UUID,
             },
         )

--- a/wazo_chatd/bus.py
+++ b/wazo_chatd/bus.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.status import Status
@@ -7,14 +7,22 @@ from xivo_bus.publisher import BusPublisher as BasePublisher
 
 
 class BusConsumer(BaseConsumer):
+    def __init__(self, subscribe=None, origin_uuid=None, **kwargs):
+        self._headers = {'origin_uuid': origin_uuid}
+        super().__init__(subscribe=subscribe, **kwargs)
+
     @classmethod
-    def from_config(cls, bus_config):
-        return cls(name='wazo-chatd', **bus_config)
+    def from_config(cls, bus_config, config):
+        print(bus_config)
+        return cls(name='wazo-chatd', origin_uuid=config['uuid'], **bus_config)
 
     def provide_status(self, status):
         status['bus_consumer']['status'] = (
             Status.ok if self.consumer_connected() else Status.fail
         )
+
+    def subscribe(self, event, handler):
+        return super().subscribe(event, handler, headers=self._headers)
 
 
 class BusPublisher(BasePublisher):

--- a/wazo_chatd/controller.py
+++ b/wazo_chatd/controller.py
@@ -38,7 +38,7 @@ class Controller:
         self.status_aggregator = StatusAggregator()
         self.rest_api = CoreRestApi(config)
         self.aio = CoreAsyncio()
-        self.bus_consumer = BusConsumer.from_config(config['bus'])
+        self.bus_consumer = BusConsumer.from_config(config['bus'], config)
         self.bus_publisher = BusPublisher.from_config(config['uuid'], config['bus'])
         self.thread_manager = ThreadManager()
         auth_client = AuthClient(**config['auth'])


### PR DESCRIPTION
when using multiple wazo-chatd connected to a single database many errors will occur because data has already been inserted or deleted from the database when the event is received