### PR TITLE
WP-1225: Teams fix line unavailable and remove invisible status

### DIFF
--- a/integration_tests/suite/test_teams_presence.py
+++ b/integration_tests/suite/test_teams_presence.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2022-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import requests
@@ -181,14 +181,6 @@ class TestTeams(TeamsIntegrationTest):
                     # DoNotDisturb -> unavailable
                     data=has_entries(state='unavailable'),
                 ),
-                has_entries(
-                    # Offline -> invisible
-                    data=has_entries(state='invisible'),
-                ),
-                has_entries(
-                    # Unknown -> invisible
-                    data=has_entries(state='invisible'),
-                ),
             ),
         )
 
@@ -243,7 +235,7 @@ class TestTeams(TeamsIntegrationTest):
 
         with self._connect_user(user1), self._connect_user(user2):
             self.microsoft.set_presence(user1.uuid, 'Busy')
-            self.microsoft.set_presence(user2.uuid, 'Offline')
+            self.microsoft.set_presence(user2.uuid, 'Away')
             self.microsoft.set_presence(user1.uuid, 'Available')
 
         assert_that(
@@ -262,7 +254,7 @@ class TestTeams(TeamsIntegrationTest):
                     message=has_entries(
                         data=has_entries(
                             uuid=str(user2.uuid),
-                            state='invisible',
+                            state='away',
                             do_not_disturb=False,
                         )
                     )

--- a/wazo_chatd/plugins/teams_presence/services.py
+++ b/wazo_chatd/plugins/teams_presence/services.py
@@ -98,6 +98,13 @@ class TeamsService:
             tenant_uuids = [self._synchronizers[user_uuid].tenant_uuid]
             presence = subscription['resource_data']
             state = PRESENCES_MAP.get(presence['availability'])
+
+            if state == 'invisible':
+                logger.debug(
+                    'discarding offline presence update for user `%s`', user_uuid
+                )
+                return
+
             dnd = state == 'unavailable'
             user = self.presence_service.get(tenant_uuids, user_uuid)
 

--- a/wazo_chatd/plugins/teams_presence/services.py
+++ b/wazo_chatd/plugins/teams_presence/services.py
@@ -103,9 +103,6 @@ class TeamsService:
 
             user.state = state
             user.do_not_disturb = dnd
-            endpoint_state = 'unavailable' if state == 'invisible' else 'available'
-            for line in user.lines:
-                line.endpoint_state = endpoint_state
 
             logger.debug('updating `%s` presence to %s', user_uuid, state)
             self.presence_service.update(user)

--- a/wazo_chatd/plugins/teams_presence/services.py
+++ b/wazo_chatd/plugins/teams_presence/services.py
@@ -28,8 +28,8 @@ PRESENCES_MAP = {
     'Busy': 'unavailable',
     'BusyIdle': 'unavailable',
     'DoNotDisturb': 'unavailable',
-    'Offline': 'invisible',
-    'PresenceUnknown': 'invisible',
+    'Offline': NotImplemented,
+    'PresenceUnknown': NotImplemented,
 }
 
 
@@ -99,9 +99,14 @@ class TeamsService:
             presence = subscription['resource_data']
             state = PRESENCES_MAP.get(presence['availability'])
 
-            if state == 'invisible':
+            # Note:
+            # Offline state is disabled because even when teams is closed,
+            # we can still received presence updates forcing an invisible presence
+            if state is NotImplemented:
                 logger.debug(
-                    'discarding offline presence update for user `%s`', user_uuid
+                    'discarding unimplemented `%s` presence update for user `%s`',
+                    presence['availability'],
+                    user_uuid,
                 )
                 return
 


### PR DESCRIPTION
This PR fixes 2 issues with the teams connector:

1. Prevents the `line is unavailable` issue when status is offline
2. Removes the ability to be set to invisible by Teams

(If unsure how to test, send me a message)