### PR TITLE
Pull request for WP-1324-paginate-init

### DIFF
--- a/integration_tests/suite/test_event_handler.py
+++ b/integration_tests/suite/test_event_handler.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -389,7 +389,7 @@ class TestEventHandler(APIIntegrationTest):
         )
 
     def test_device_state_changed_create_endpoint(self):
-        endpoint_name = 'missing-endpoint'
+        endpoint_name = 'PJSIP/missing-endpoint'
 
         self.bus.send_device_state_changed_event(endpoint_name, 'ONHOLD')
 

--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -49,7 +49,7 @@ _DEFAULT_CONFIG = {
         'port': 9486,
         'prefix': None,
         'https': False,
-        'timeout': 90,
+        'timeout': 30,
     },
     'consul': {'scheme': 'http', 'port': 8500},
     'service_discovery': {

--- a/wazo_chatd/plugins/presences/bus_consume.py
+++ b/wazo_chatd/plugins/presences/bus_consume.py
@@ -211,10 +211,12 @@ class BusEventHandler:
             self._notifier.updated(user)
 
     def _device_state_change(self, event):
+        logger.debug('Device state change: %s', event)
         endpoint_name = event['Device']
         is_pjsip = endpoint_name.startswith('PJSIP')
         is_sccp = endpoint_name.startswith('SCCP')
-        if not is_pjsip or not is_sccp:
+        if not (is_pjsip or is_sccp):
+            logger.debug('Ignoring non-pjsip or sccp device "%s"', endpoint_name)
             return
 
         state = DEVICE_STATE_MAP.get(event['State'], 'unavailable')

--- a/wazo_chatd/plugins/presences/bus_consume.py
+++ b/wazo_chatd/plugins/presences/bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -212,7 +212,9 @@ class BusEventHandler:
 
     def _device_state_change(self, event):
         endpoint_name = event['Device']
-        if endpoint_name.startswith('Custom:'):
+        is_pjsip = endpoint_name.startswith('PJSIP')
+        is_sccp = endpoint_name.startswith('SCCP')
+        if not is_pjsip or not is_sccp:
             return
 
         state = DEVICE_STATE_MAP.get(event['State'], 'unavailable')

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -94,11 +94,12 @@ class Initiator:
         result = callback(limit=limit, offset=0)
         total = result['total']
         items = result['items']
-        offset = limit
+        offset = len(items)
         while offset < total:
-            items.extend(callback(offset=offset)['items'])
-            offset += limit
-
+            new_items = callback(offset=offset)['items']
+            items.extend(new_items)
+            offset += len(new_items)
+        assert len(items) == total
         return {'items': items, 'total': total}
 
     def initiate(self):

--- a/wazo_chatd/plugins/presences/initiator_thread.py
+++ b/wazo_chatd/plugins/presences/initiator_thread.py
@@ -1,8 +1,9 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import itertools
 import logging
+import signal
 import threading
 
 import requests
@@ -20,6 +21,7 @@ class InitiatorThread:
         self._retry_time_failed = itertools.chain(
             (1, 2, 4, 8, 16), itertools.repeat(32)
         )
+        self._retry_time_failed_timeout = itertools.chain((30, 60, 120, 240, 480))
 
     def start(self):
         if self._started:
@@ -48,6 +50,23 @@ class InitiatorThread:
         logger.debug('Starting presence initialization')
         try:
             self._initiator.initiate()
+        except requests.ReadTimeout as e:
+            try:
+                self._retry_time = next(self._retry_time_failed_timeout)
+            except StopIteration:
+                logger.error(
+                    'Timeout to fetch data for initialization (%s). Stopping wazo-chatd...',
+                    e,
+                )
+                self._stopped.set()
+                signal.raise_signal(signal.SIGTERM)
+                return
+
+            logger.warning(
+                'Timeout to fetch data for initialization (%s). Retrying in %s seconds...',
+                e,
+                self._retry_time,
+            )
         except (requests.RequestException, SQLAlchemyError) as e:
             self._retry_time = next(self._retry_time_failed)
             logger.warning(

--- a/wazo_chatd/plugins/presences/tests/test_bus_consume.py
+++ b/wazo_chatd/plugins/presences/tests/test_bus_consume.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
@@ -18,7 +18,19 @@ class TestBusEventHandler(TestCase):
             'State': 'unavailable',
             'Device': 'Custom:*7351033***223',
         }
-
         self.handler._device_state_change(event)
+        self.dao.endpoint.find_or_create.assert_not_called()
 
+        event = {
+            'State': 'unavailable',
+            'Device': 'MWI:1001@internal',
+        }
+        self.handler._device_state_change(event)
+        self.dao.endpoint.find_or_create.assert_not_called()
+
+        event = {
+            'State': 'unavailable',
+            'Device': 'Queue:grp-01wazo-e0cc9e04-a40f-4d1d-ac51-58634b1cf5b3_avail',
+        }
+        self.handler._device_state_change(event)
         self.dao.endpoint.find_or_create.assert_not_called()

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -1,0 +1,46 @@
+from unittest import mock
+
+import pytest
+from wazo_amid_client import Client as AmidClient
+from wazo_auth_client import Client as AuthClient
+from wazo_confd_client import Client as ConfdClient
+
+from wazo_chatd.database.queries import DAO
+from wazo_chatd.plugins.presences.initiator import Initiator
+
+
+@pytest.fixture
+def initiator():
+    return Initiator(
+        dao=mock.create_autospec(DAO, instance=True),
+        auth=mock.create_autospec(AuthClient, instance=True),
+        amid=mock.create_autospec(AmidClient, instance=True),
+        confd=mock.create_autospec(ConfdClient, instance=True),
+    )
+
+
+def test_paginate_proxy(initiator: Initiator):
+    def paginated_callback(recurse, limit, offset):
+        return {
+            'items': [{'id': offset + i} for i in range(1, limit + 1)],
+            'total': limit * 5,
+        }
+
+    callback_mock = mock.Mock(side_effect=paginated_callback)
+    results = initiator._paginate_proxy(callback_mock, limit=2)
+    assert results == {
+        'items': [
+            {'id': 1},
+            {'id': 2},
+            {'id': 3},
+            {'id': 4},
+            {'id': 5},
+            {'id': 6},
+            {'id': 7},
+            {'id': 8},
+            {'id': 9},
+            {'id': 10},
+        ],
+        'total': 10,
+    }
+    assert callback_mock.call_count == 5


### PR DESCRIPTION
**presence: filter all non pjsip/sccp devices**

why: We only want to track event for PJSIP/SCCP endpoints

**initialization: use pagination to fetch resources**

why: avoid to reach timeout

**initialization: use different strategy on ReadTimeout**

why: The main reasons to have ReadTimeout are:
* service is under heavy load
* too much resource and service will ALWAYS raise ReadTimeout

Solutions:
- Use different retry_time to let the system decrease its load
- stop wazo-chatd after 12 min (arbitrary among of time that should be enough
  to have a "big" system stable after wazo-service restart)

### TODO
- add unittests for paginate logic (IMHO integration tests would be overkill)
- Fix integration tests / mock calls

Depends-On: https://github.com/wazo-platform/wazo-test-helpers/pull/101