### PR TITLE
Use marshmallow version 3.18.0 from Bookworm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ jinja2==3.0.3  # from flask
 jsonpatch==1.21
 kombu==5.0.2
 markupsafe==2.0.1 # from jinja
-marshmallow==3.10.0
+marshmallow==3.18.0
 psycopg2-binary==2.8.6
 python-consul==1.1.0
 python-dateutil==2.8.1  # from marshmallow, to accept more date formats

--- a/wazo_chatd/plugins/presences/schemas.py
+++ b/wazo_chatd/plugins/presences/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import post_dump, pre_load
@@ -86,8 +86,8 @@ class UserPresenceSchema(Schema):
 
 
 class ListRequestSchema(Schema):
-    recurse = fields.Boolean(missing=False)
-    user_uuid = fields.List(fields.UUID(), missing=list, attribute='uuids')
+    recurse = fields.Boolean(load_default=False)
+    user_uuid = fields.List(fields.UUID(), load_default=list, attribute='uuids')
 
     @pre_load
     def convert_user_uuid_to_list(self, data, **kwargs):

--- a/wazo_chatd/plugins/rooms/schemas.py
+++ b/wazo_chatd/plugins/rooms/schemas.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from marshmallow import pre_load, validates_schema
@@ -19,7 +19,7 @@ class RoomSchema(Schema):
 
     name = fields.String(allow_none=True)
 
-    users = fields.Nested('RoomUserSchema', many=True, missing=list)
+    users = fields.Nested('RoomUserSchema', many=True, load_default=list)
 
 
 class MessageSchema(Schema):
@@ -58,7 +58,7 @@ class MessageListRequestSchema(_ListSchema):
 
 
 class RoomListRequestSchema(Schema):
-    user_uuid = fields.List(fields.UUID(), missing=list, attribute='user_uuids')
+    user_uuid = fields.List(fields.UUID(), load_default=list, attribute='user_uuids')
 
     @pre_load
     def convert_user_uuid_to_list(self, data, **kwargs):

--- a/wazo_chatd/plugins/teams_presence/schemas.py
+++ b/wazo_chatd/plugins/teams_presence/schemas.py
@@ -8,7 +8,7 @@ from xivo.mallow_helpers import Schema
 
 class PresenceResourceSchema(Schema):
     id = fields.String(load_only=True, required=True)
-    activity = fields.String(load_only=True, missing='', allow_none=False)
+    activity = fields.String(load_only=True, load_default='', allow_none=False)
     availability = fields.String(
         load_only=True,
         required=True,


### PR DESCRIPTION
This change uses the Bookworm version of marshmallow to reduce the scope of changes that are going to happen when doing the upgrade