### PR TITLE
integration-tests: log all DB statements

### DIFF
--- a/integration_tests/Dockerfile-db
+++ b/integration_tests/Dockerfile-db
@@ -1,0 +1,4 @@
+FROM wazoplatform/wazo-chatd-db
+LABEL maintainer="Wazo Maintainers <dev@wazo.community>"
+
+RUN echo "log_statement=all" >> "/etc/postgresql/13/main/postgresql.conf"

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -17,5 +17,6 @@ chatd-test: egg-info
 
 db:
 	docker build -f ../contribs/docker/Dockerfile-db -t wazoplatform/wazo-chatd-db ..
+	docker build -f Dockerfile-db -t wazoplatform/wazo-chatd-db-test ..
 
 .PHONY: test-setup test egg-info chatd chatd-test

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - '9497'
 
   postgres:
-    image: wazoplatform/wazo-chatd-db
+    image: wazoplatform/wazo-chatd-db-test
     ports:
       - "5432"
 


### PR DESCRIPTION
Why:

* Allows debugging race conditions issues