### PR TITLE
fix-unhandled-event-during-init

### DIFF
--- a/wazo_chatd/plugins/presences/bus_consume.py
+++ b/wazo_chatd/plugins/presences/bus_consume.py
@@ -52,7 +52,8 @@ class BusInitiatorHandler:
     def handle_init_process(self, func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if self._initiator.in_progress():
+            is_callback_handled = hasattr(func, 'init_fetched_resource')
+            if self._initiator.in_progress() and is_callback_handled:
                 if self._initiator.has_fetched(func.init_fetched_resource):
                     callback = partial(func, *args, **kwargs)
                     self._callbacks_delayed.append(callback)


### PR DESCRIPTION
Since we have a catch Exception in the event handler thread, this
traceback doesn't cause any issue. But create bad log... So adding a
check on the callback before getting attribute will ignore "unsupported"
callbacks
