### PR TITLE
improve-init-resilience

### DIFF
--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -139,7 +139,8 @@ class Initiator:
             new_items = callback(offset=offset)['items']
             items.extend(new_items)
             offset += len(new_items)
-        assert len(items) == total
+        if len(items) != total:
+            logger.warning('Fetched %d items but total was %d', len(items), total)
         return {'items': items, 'total': total}
 
     def reset_initialized(self):


### PR DESCRIPTION
Why: the assert crashes initialization when fetched item count differs
from total, which is expected for sessions (non-service users have
sessions that have no chatd presence). A partial desync is acceptable
since resources created during init will be caught by bus events.
A warning preserves observability for unexpected mismatches without
blocking startup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: replaces a hard `assert` with a warning log to prevent presence initialization from crashing when paginated APIs report a `total` that doesn’t match returned items.
> 
> **Overview**
> Makes presence initialization more resilient by removing the strict `assert len(items) == total` check in `Initiator._paginate_proxy`.
> 
> When pagination returns fewer/more items than the reported `total`, startup now continues and logs a warning (`Fetched %d items but total was %d`) instead of aborting initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d794da0e938cac6afda88cc217fb48ff4e080f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->