### PR TITLE
[ITEM-101] Add connector database models and migration

### DIFF
--- a/alembic/versions/4ca51d8f3bb2_add_connector_models.py
+++ b/alembic/versions/4ca51d8f3bb2_add_connector_models.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""add connector models
+
+Revision ID: 4ca51d8f3bb2
+Revises: e700870ac284
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy_utils import UUIDType
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '4ca51d8f3bb2'
+down_revision = 'e700870ac284'
+
+
+def upgrade() -> None:
+    # RoomUser: add identity column for external participants
+    op.add_column(
+        'chatd_room_user',
+        sa.Column('identity', sa.String, nullable=True),
+    )
+    op.create_index(
+        'chatd_room_user__idx__identity',
+        'chatd_room_user',
+        ['identity'],
+    )
+
+    # UserIdentity: user-to-external-identity mappings
+    op.create_table(
+        'chatd_user_identity',
+        sa.Column(
+            'uuid',
+            UUIDType(),
+            server_default=sa.text('uuid_generate_v4()'),
+            primary_key=True,
+        ),
+        sa.Column(
+            'tenant_uuid',
+            UUIDType(),
+            sa.ForeignKey('chatd_tenant.uuid', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column(
+            'user_uuid',
+            UUIDType(),
+            sa.ForeignKey('chatd_user.uuid', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('backend', sa.String, nullable=False),
+        sa.Column('type', sa.String, nullable=False),
+        sa.Column('identity', sa.String, nullable=False),
+        sa.Column(
+            'extra',
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.create_unique_constraint(
+        'chatd_user_identity__uq__backend_identity_type',
+        'chatd_user_identity',
+        ['backend', 'identity', 'type'],
+    )
+    op.create_index(
+        'chatd_user_identity__idx__tenant_uuid',
+        'chatd_user_identity',
+        ['tenant_uuid'],
+    )
+    op.create_index(
+        'chatd_user_identity__idx__user_uuid',
+        'chatd_user_identity',
+        ['user_uuid'],
+    )
+
+    # MessageMeta: optional 1:1 delivery metadata for RoomMessage
+    op.create_table(
+        'chatd_message_meta',
+        sa.Column(
+            'message_uuid',
+            UUIDType(),
+            sa.ForeignKey('chatd_room_message.uuid', ondelete='CASCADE'),
+            primary_key=True,
+        ),
+        sa.Column('type', sa.String, nullable=True),
+        sa.Column('backend', sa.String, nullable=True),
+        sa.Column(
+            'sender_identity_uuid',
+            UUIDType(),
+            sa.ForeignKey('chatd_user_identity.uuid', ondelete='SET NULL'),
+            nullable=True,
+        ),
+        sa.Column('retry_count', sa.Integer, nullable=False, server_default='0'),
+        sa.Column('external_id', sa.String, nullable=True),
+        sa.Column(
+            'extra',
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.create_index(
+        'chatd_message_meta__idx__extra',
+        'chatd_message_meta',
+        ['extra'],
+        postgresql_using='gin',
+    )
+    op.create_index(
+        'chatd_message_meta__idx__external_id',
+        'chatd_message_meta',
+        ['external_id'],
+    )
+
+    # DeliveryRecord: append-only status updates from connectors
+    op.create_table(
+        'chatd_delivery_record',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            'message_uuid',
+            UUIDType(),
+            sa.ForeignKey('chatd_message_meta.message_uuid', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('status', sa.String, nullable=False),
+        sa.Column('reason', sa.String, nullable=True),
+        sa.Column(
+            'timestamp',
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("(now() at time zone 'utc')"),
+        ),
+    )
+    op.create_index(
+        'chatd_delivery_record__idx__message_uuid',
+        'chatd_delivery_record',
+        ['message_uuid'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('chatd_delivery_record')
+    op.drop_table('chatd_message_meta')
+    op.drop_table('chatd_user_identity')
+    op.drop_index('chatd_room_user__idx__identity', 'chatd_room_user')
+    op.drop_column('chatd_room_user', 'identity')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ check_untyped_defs = true
 warn_unused_configs = true
 ignore_missing_imports = true
 
+# Tests use unittest.mock and hamcrest extensively — Mock/AsyncMock
+# patterns and hamcrest matchers trigger false positives.
+[[tool.mypy.overrides]]
+module = ["*.tests.*", "integration_tests.*"]
+disable_error_code = ["method-assign", "attr-defined", "arg-type"]
+
 [tool.black]
 skip-string-normalization = true
 

--- a/wazo_chatd/database/delivery.py
+++ b/wazo_chatd/database/delivery.py
@@ -1,0 +1,16 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class DeliveryStatus(str, Enum):
+    PENDING = 'pending'
+    SENDING = 'sending'
+    SENT = 'sent'
+    DELIVERED = 'delivered'
+    FAILED = 'failed'
+    RETRYING = 'retrying'
+    DEAD_LETTER = 'dead_letter'

--- a/wazo_chatd/database/models.py
+++ b/wazo_chatd/database/models.py
@@ -346,7 +346,7 @@ class MessageMeta(Base):  # type: ignore[misc, valid-type]
         'DeliveryRecord',
         uselist=True,
         cascade='all,delete-orphan',
-        order_by=('DeliveryRecord.timestamp', 'DeliveryRecord.id'),
+        order_by='DeliveryRecord.timestamp, DeliveryRecord.id',
     )
 
     @hybrid_property
@@ -383,7 +383,9 @@ class MessageMeta(Base):  # type: ignore[misc, valid-type]
 @generic_repr
 class DeliveryRecord(Base):  # type: ignore[misc, valid-type]
     __tablename__ = 'chatd_delivery_record'
-    __table_args__ = (Index('chatd_delivery_record__idx__message_uuid', 'message_uuid'),)
+    __table_args__ = (
+        Index('chatd_delivery_record__idx__message_uuid', 'message_uuid'),
+    )
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     message_uuid: UUIDType = Column(

--- a/wazo_chatd/database/models.py
+++ b/wazo_chatd/database/models.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -15,11 +15,14 @@ from sqlalchemy import (
     Integer,
     String,
     Text,
+    select,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import declarative_base, relationship
-from sqlalchemy.schema import Index
+from sqlalchemy.schema import Index, UniqueConstraint
 from sqlalchemy_utils import UUIDType, generic_repr
 
 if TYPE_CHECKING:
@@ -216,6 +219,7 @@ class Room(Base):  # type: ignore[misc, valid-type]
 @generic_repr
 class RoomUser(Base):  # type: ignore[misc, valid-type]
     __tablename__ = 'chatd_room_user'
+    __table_args__ = (Index('chatd_room_user__idx__identity', 'identity'),)
 
     room_uuid: UUIDType = Column(
         UUIDType(),
@@ -225,6 +229,10 @@ class RoomUser(Base):  # type: ignore[misc, valid-type]
     uuid = Column(UUIDType(), primary_key=True)
     tenant_uuid = Column(UUIDType(), primary_key=True)
     wazo_uuid = Column(UUIDType(), primary_key=True)
+
+    # External participants: "+15559876", "bob@remote.wazo.io", etc.
+    # None for internal Wazo users.
+    identity = Column(String, nullable=True)
 
 
 @generic_repr
@@ -253,3 +261,141 @@ class RoomMessage(Base):  # type: ignore[misc, valid-type]
     )
 
     room: RelationshipProperty[Room] = relationship('Room', viewonly=True)
+    meta: RelationshipProperty[MessageMeta | None] = relationship(
+        'MessageMeta',
+        uselist=False,
+        cascade='all,delete-orphan',
+        back_populates='message',
+    )
+
+
+@generic_repr
+class UserIdentity(Base):  # type: ignore[misc, valid-type]
+    __tablename__ = 'chatd_user_identity'
+    __table_args__ = (
+        UniqueConstraint('backend', 'identity', 'type'),
+        Index('chatd_user_identity__idx__tenant_uuid', 'tenant_uuid'),
+        Index('chatd_user_identity__idx__user_uuid', 'user_uuid'),
+    )
+
+    uuid = Column(
+        UUIDType(), server_default=text('uuid_generate_v4()'), primary_key=True
+    )
+    tenant_uuid: UUIDType = Column(
+        UUIDType(),
+        ForeignKey('chatd_tenant.uuid', ondelete='CASCADE'),
+        nullable=False,
+    )
+    user_uuid: UUIDType = Column(
+        UUIDType(),
+        ForeignKey('chatd_user.uuid', ondelete='CASCADE'),
+        nullable=False,
+    )
+    backend = Column(String, nullable=False)
+    type_ = Column('type', String, nullable=False)
+    identity = Column(String, nullable=False)
+    extra = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
+    tenant: RelationshipProperty[Tenant] = relationship(
+        'Tenant', uselist=False, viewonly=True
+    )
+    user: RelationshipProperty[User] = relationship(
+        'User', uselist=False, viewonly=True
+    )
+
+
+@generic_repr
+class MessageMeta(Base):  # type: ignore[misc, valid-type]
+    __tablename__ = 'chatd_message_meta'
+    __table_args__ = (
+        Index(
+            'chatd_message_meta__idx__extra',
+            'extra',
+            postgresql_using='gin',
+        ),
+        Index('chatd_message_meta__idx__external_id', 'external_id'),
+    )
+
+    message_uuid: UUIDType = Column(
+        UUIDType(),
+        ForeignKey('chatd_room_message.uuid', ondelete='CASCADE'),
+        primary_key=True,
+    )
+    type_ = Column('type', String, nullable=True)
+    backend = Column(String, nullable=True)
+    sender_identity_uuid: UUIDType = Column(
+        UUIDType(),
+        ForeignKey('chatd_user_identity.uuid', ondelete='SET NULL'),
+        nullable=True,
+    )
+    retry_count = Column(Integer, nullable=False, default=0, server_default='0')
+    external_id = Column(String, nullable=True)
+    extra = Column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+
+    sender_identity: RelationshipProperty[UserIdentity | None] = relationship(
+        'UserIdentity', uselist=False, viewonly=True
+    )
+    message: RelationshipProperty[RoomMessage] = relationship(
+        'RoomMessage', uselist=False, back_populates='meta'
+    )
+    records: RelationshipProperty[list[DeliveryRecord]] = relationship(
+        'DeliveryRecord',
+        uselist=True,
+        cascade='all,delete-orphan',
+        order_by='DeliveryRecord.timestamp',
+    )
+
+    @hybrid_property
+    def status(self) -> str | None:
+        return self.records[-1].status if self.records else None
+
+    @status.expression  # type: ignore[no-redef]
+    def status(cls):
+        return (
+            select(DeliveryRecord.status)
+            .where(DeliveryRecord.message_uuid == cls.message_uuid)
+            .order_by(DeliveryRecord.timestamp.desc())
+            .limit(1)
+            .correlate_except(DeliveryRecord)
+            .scalar_subquery()
+        )
+
+    @hybrid_property
+    def updated_at(self) -> datetime | None:
+        return self.records[-1].timestamp if self.records else None
+
+    @updated_at.expression  # type: ignore[no-redef]
+    def updated_at(cls):
+        return (
+            select(DeliveryRecord.timestamp)
+            .where(DeliveryRecord.message_uuid == cls.message_uuid)
+            .order_by(DeliveryRecord.timestamp.desc())
+            .limit(1)
+            .correlate_except(DeliveryRecord)
+            .scalar_subquery()
+        )
+
+
+@generic_repr
+class DeliveryRecord(Base):  # type: ignore[misc, valid-type]
+    __tablename__ = 'chatd_delivery_record'
+    __table_args__ = (Index('chatd_delivery_record__idx__message_uuid', 'message_uuid'),)
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    message_uuid: UUIDType = Column(
+        UUIDType(),
+        ForeignKey('chatd_message_meta.message_uuid', ondelete='CASCADE'),
+        nullable=False,
+    )
+    status = Column(String, nullable=False)
+    reason = Column(String, nullable=True)
+    timestamp = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=text("(now() at time zone 'utc')"),
+        nullable=False,
+    )

--- a/wazo_chatd/database/models.py
+++ b/wazo_chatd/database/models.py
@@ -346,7 +346,7 @@ class MessageMeta(Base):  # type: ignore[misc, valid-type]
         'DeliveryRecord',
         uselist=True,
         cascade='all,delete-orphan',
-        order_by='DeliveryRecord.timestamp',
+        order_by=('DeliveryRecord.timestamp', 'DeliveryRecord.id'),
     )
 
     @hybrid_property
@@ -358,7 +358,7 @@ class MessageMeta(Base):  # type: ignore[misc, valid-type]
         return (
             select(DeliveryRecord.status)
             .where(DeliveryRecord.message_uuid == cls.message_uuid)
-            .order_by(DeliveryRecord.timestamp.desc())
+            .order_by(DeliveryRecord.timestamp.desc(), DeliveryRecord.id.desc())
             .limit(1)
             .correlate_except(DeliveryRecord)
             .scalar_subquery()
@@ -373,7 +373,7 @@ class MessageMeta(Base):  # type: ignore[misc, valid-type]
         return (
             select(DeliveryRecord.timestamp)
             .where(DeliveryRecord.message_uuid == cls.message_uuid)
-            .order_by(DeliveryRecord.timestamp.desc())
+            .order_by(DeliveryRecord.timestamp.desc(), DeliveryRecord.id.desc())
             .limit(1)
             .correlate_except(DeliveryRecord)
             .scalar_subquery()

--- a/wazo_chatd/exceptions.py
+++ b/wazo_chatd/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from xivo.rest_api_helpers import APIException
@@ -51,3 +51,10 @@ class UnknownRoomException(APIException):
         msg = f'No such room: "{room_uuid}"'
         details = {'uuid': str(room_uuid)}
         super().__init__(404, msg, 'unknown-room', details, 'rooms')
+
+
+class UnknownUserIdentityException(APIException):
+    def __init__(self, identity_uuid: str) -> None:
+        msg = f'No such user identity: "{identity_uuid}"'
+        details = {'uuid': str(identity_uuid)}
+        super().__init__(404, msg, 'unknown-user-identity', details, 'identities')


### PR DESCRIPTION
## Summary
- Add `UserIdentity`, `MessageMeta`, and `DeliveryRecord` SQLAlchemy models
- Add `DeliveryStatus` enum (pending, sending, sent, delivered, failed, retrying, dead_letter)
- Add migration creating `chatd_user_identity`, `chatd_message_meta`, `chatd_delivery_record` tables
- Add GIN index on `message_meta.extra` for JSONB signature and idempotency lookups
- Add `back_populates` on `RoomMessage.meta` / `MessageMeta.message` relationship
- Add `UnknownUserIdentityException`

## Context
First PR in the multichannel communication stack. These models support:
- `UserIdentity`: maps Wazo users to external messaging identities (phone numbers, etc.)
- `MessageMeta`: connector metadata for messages (type, backend, delivery status)
- `DeliveryRecord`: tracks delivery state transitions for outbound messages

## Test plan
- [ ] Migration applies cleanly on a fresh database
- [ ] Models are importable and relationships work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new persisted connector metadata and delivery-status history tables plus a new indexed column on `chatd_room_user`, which carries migration/compatibility risk for existing deployments and query performance considerations (JSONB GIN index, hybrid subqueries).
> 
> **Overview**
> Adds database support for connector-based messaging by introducing `UserIdentity`, `MessageMeta`, and `DeliveryRecord` models, plus a new `DeliveryStatus` enum for delivery state values.
> 
> Ships an Alembic migration that adds `chatd_room_user.identity` (indexed) and creates the new tables with key constraints and lookup indexes (including a GIN index on `chatd_message_meta.extra`), and wires `RoomMessage` to optional 1:1 `MessageMeta` with delivery status/updated-at derived from the latest `DeliveryRecord`.
> 
> Also adds `UnknownUserIdentityException` and relaxes mypy checking in test modules via per-module overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab71352fc7582ce66bae6cdb2f15fac9763797b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->