### PR TITLE
[ITEM-101] Add async delivery pipeline

### DIFF
--- a/wazo_chatd/plugins/connectors/bus_consume.py
+++ b/wazo_chatd/plugins/connectors/bus_consume.py
@@ -1,0 +1,22 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wazo_chatd.bus import BusConsumer
+    from wazo_chatd.plugins.connectors.router import ConnectorRouter
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectorBusEventHandler:
+    def __init__(self, bus_consumer: BusConsumer, router: ConnectorRouter) -> None:
+        self._bus_consumer = bus_consumer
+        self._router = router
+
+    def subscribe(self) -> None:
+        pass

--- a/wazo_chatd/plugins/connectors/executor.py
+++ b/wazo_chatd/plugins/connectors/executor.py
@@ -1,0 +1,445 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Delivery executor — runs in the server (worker) process.
+
+Uses asyncio for I/O-bound operations (DB writes, external API calls).
+Sync connector implementations are wrapped with ``asyncio.to_thread()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import logging
+import uuid
+from typing import Any
+
+from wazo_chatd.database.async_helpers import get_async_session
+from wazo_chatd.database.delivery import DeliveryStatus
+from wazo_chatd.database.models import (
+    DeliveryRecord,
+    MessageMeta,
+    Room,
+    RoomMessage,
+    RoomUser,
+)
+from wazo_chatd.database.queries.async_.room import AsyncRoomDAO
+from wazo_chatd.database.queries.async_.user_identity import AsyncUserIdentityDAO
+from wazo_chatd.plugin_helpers.dependencies import ConfigDict
+from wazo_chatd.plugins.connectors.connector import Connector
+from wazo_chatd.plugins.connectors.exceptions import ConnectorSendError
+from wazo_chatd.plugins.connectors.notifier import AsyncNotifier
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.store import ConnectorStore
+from wazo_chatd.plugins.connectors.types import (
+    InboundMessage,
+    OutboundMessage,
+    StatusUpdate,
+)
+
+logger = logging.getLogger(__name__)
+
+OUTBOUND_MAX_RETRIES: int = 3
+OUTBOUND_RETRY_DELAYS: list[int] = [30, 120, 300]
+INBOUND_MAX_RETRIES: int = 3
+INBOUND_RETRY_DELAYS: list[int] = [2, 5, 10]
+ECHO_WINDOW_SECONDS: int = 60
+
+
+def generate_message_signature(sender_identity: str, body: str) -> str:
+    """Generate a dedup signature to detect inbound echoes of outbound messages.
+
+    Combines the sender identity with a normalized body (lowercase, ASCII-only,
+    no whitespace, capped at 160 chars) and returns a truncated SHA-256 hash.
+    The 160-char cap ensures consistent signatures across providers regardless
+    of SMS segment reassembly behavior.
+    """
+    normalized = ''.join(c.lower() for c in body if c.isascii() and not c.isspace())
+    payload = sender_identity + ':' + normalized[:160]
+
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+class DeliveryExecutor:
+    """Executes connector send operations with delivery tracking and retries.
+
+    Connectors are initialized locally from configuration received via
+    pipe from the main process.  The executor never queries the DB for
+    provider configuration — it only writes delivery status records.
+    """
+
+    def __init__(
+        self,
+        config: ConfigDict,
+        registry: ConnectorRegistry,
+        notifier: AsyncNotifier,
+        store: ConnectorStore,
+    ) -> None:
+        self._wazo_uuid: str = str(config.get('uuid', ''))
+        self._connector_config: dict[str, Any] = dict(config.get('connectors', {}))
+        self._registry = registry
+        self._notifier = notifier
+        self._store = store
+        self._room_dao = AsyncRoomDAO()
+        self._user_identity_dao = AsyncUserIdentityDAO()
+
+    async def route_outbound(self, meta: MessageMeta) -> None:
+        assert (sender_record := meta.sender_identity)
+
+        session = get_async_session()
+        message = meta.message
+        room = message.room
+
+        sender_identity = str(sender_record.identity)
+        backend_name = str(sender_record.backend)
+        message_type = str(sender_record.type_)
+
+        recipient_identity = await self._resolve_recipient_identity(
+            room, message, backend_name
+        )
+        if not recipient_identity:
+            return
+
+        has_internal_recipient = any(
+            u.uuid != message.user_uuid and not u.identity for u in room.users
+        )
+
+        extra = {
+            **(meta.extra or {}),
+            'outbound_idempotency_key': str(meta.message_uuid),
+        }
+
+        if has_internal_recipient:
+            extra['message_signature'] = generate_message_signature(
+                sender_identity, str(message.content or '')
+            )
+
+        meta.extra = extra  # type: ignore[assignment]
+        await session.flush()
+
+        outbound = OutboundMessage(
+            room_uuid=str(room.uuid),
+            message_uuid=str(meta.message_uuid),
+            sender_uuid=str(message.user_uuid),
+            body=str(message.content or ''),
+            message_type=message_type,
+            sender_identity=sender_identity,
+            recipient_identity=recipient_identity,
+            metadata={'idempotency_key': str(meta.message_uuid)},
+        )
+
+        await self.execute(
+            outbound,
+            meta,
+            tenant_uuid=str(sender_record.tenant_uuid),
+        )
+
+    async def _resolve_recipient_identity(
+        self,
+        room: Room,
+        message: RoomMessage,
+        backend: str,
+    ) -> str | None:
+        recipients = [u for u in room.users if u.uuid != message.user_uuid]
+        if not recipients:
+            return None
+
+        recipient = recipients[0]
+
+        if recipient.identity:
+            return str(recipient.identity)
+
+        identities = await self._user_identity_dao.list_by_user(
+            str(recipient.uuid), backends=[backend]
+        )
+        if not identities:
+            logger.warning(
+                'No %s identity for recipient %s, skipping',
+                backend,
+                recipient.uuid,
+            )
+            return None
+
+        return str(identities[0].identity)
+
+    async def route_inbound(
+        self,
+        inbound: InboundMessage,
+        attempt: int = 0,
+    ) -> None:
+        idempotency_key = inbound.metadata.get('idempotency_key')
+        if idempotency_key:
+            is_duplicate = await self._room_dao.check_duplicate_idempotency_key(
+                str(idempotency_key)
+            )
+            if is_duplicate:
+                logger.info(
+                    'Duplicate inbound message skipped (key=%s)',
+                    idempotency_key,
+                )
+                return
+
+        sender_identity = inbound.sender
+        try:
+            backend_cls = self._registry.get_backend(inbound.backend)
+            sender_identity = backend_cls.normalize_identity(sender_identity)
+        except (KeyError, ValueError, TypeError):
+            pass
+
+        resolved = await self._user_identity_dao.resolve_users_by_identities(
+            [inbound.recipient, sender_identity]
+        )
+
+        recipient_user = resolved.get(inbound.recipient)
+        if not recipient_user:
+            logger.warning(
+                'No wazo user found for recipient %s (backend=%s), dropping',
+                inbound.recipient,
+                inbound.backend,
+            )
+            return
+
+        tenant_uuid = str(recipient_user.tenant_uuid)
+        wazo_uuid = self._wazo_uuid
+
+        recipient_participant = RoomUser(
+            uuid=recipient_user.uuid,
+            tenant_uuid=tenant_uuid,
+            wazo_uuid=wazo_uuid,
+        )
+
+        sender_user = resolved.get(sender_identity)
+        if sender_user:
+            sender_participant = RoomUser(
+                uuid=sender_user.uuid,
+                tenant_uuid=tenant_uuid,
+                wazo_uuid=wazo_uuid,
+            )
+        else:
+            sender_participant = RoomUser(
+                uuid=uuid.uuid5(uuid.NAMESPACE_URL, f'{tenant_uuid}:{sender_identity}'),
+                tenant_uuid=tenant_uuid,
+                wazo_uuid=wazo_uuid,
+                identity=sender_identity,
+            )
+        room = await self._room_dao.find_or_create_room(
+            tenant_uuid=tenant_uuid,
+            participants=[sender_participant, recipient_participant],
+        )
+
+        if sender_user and inbound.body:
+            signature = generate_message_signature(sender_identity, inbound.body)
+            is_duplicate = await self._room_dao.has_matching_signature(
+                str(room.uuid), signature, ECHO_WINDOW_SECONDS
+            )
+            if is_duplicate:
+                logger.info(
+                    'Duplicate inbound message dropped (room=%s, sender=%s)',
+                    room.uuid,
+                    sender_identity,
+                )
+                return
+
+        extra: dict[str, str] = {'external_id': inbound.external_id}
+        if idempotency_key:
+            extra['idempotency_key'] = str(idempotency_key)
+
+        record = DeliveryRecord(status=DeliveryStatus.DELIVERED.value)
+        meta = MessageMeta(
+            backend=inbound.backend,
+            type_=inbound.message_type,
+            extra=extra,
+            records=[record],
+        )
+        message = RoomMessage(
+            room_uuid=room.uuid,
+            content=inbound.body,
+            user_uuid=sender_participant.uuid,
+            tenant_uuid=tenant_uuid,
+            wazo_uuid=wazo_uuid,
+            meta=meta,
+        )
+        try:
+            await self._room_dao.add_message(room, message)
+        except Exception:
+            if attempt < INBOUND_MAX_RETRIES:
+                delay = INBOUND_RETRY_DELAYS[attempt]
+                logger.warning(
+                    'Failed to persist inbound from %s, retrying in %ds (%d/%d)',
+                    inbound.sender,
+                    delay,
+                    attempt + 1,
+                    INBOUND_MAX_RETRIES,
+                )
+                await asyncio.sleep(delay)
+                return await self.route_inbound(inbound, attempt + 1)
+            raise
+
+        await self._notifier.message_created(room, message)
+        logger.info(
+            'Inbound message from %s persisted (room=%s)',
+            inbound.sender,
+            room.uuid,
+        )
+
+    async def route_status_update(self, update: StatusUpdate) -> None:
+        try:
+            backend_cls = self._registry.get_backend(update.backend)
+        except KeyError:
+            logger.warning(
+                'No connector for backend %r, dropping status update',
+                update.backend,
+            )
+            return
+
+        status_map = getattr(backend_cls, 'status_map', {})
+        mapped_status = status_map.get(update.status)
+        if not mapped_status:
+            logger.debug(
+                'Ignoring unmapped provider status %r for %s',
+                update.status,
+                update.external_id,
+            )
+            return
+
+        meta = await self._room_dao.get_message_meta_by_external_id(update.external_id)
+        if not meta:
+            logger.warning(
+                'No MessageMeta found for external_id %s, dropping status update',
+                update.external_id,
+            )
+            return
+
+        record = DeliveryRecord(
+            status=mapped_status.value,
+            reason=update.error_code or None,
+        )
+        await self._room_dao.add_delivery_record(meta, record)
+
+        room = meta.message.room
+        await self._notifier.delivery_status_updated(meta, record, room)
+
+        logger.info(
+            'Status update: %s → %s (external_id=%s)',
+            update.status,
+            mapped_status.value,
+            update.external_id,
+        )
+
+    async def recover_pending_deliveries(
+        self,
+    ) -> list[tuple[MessageMeta, float]]:
+        metas = await self._room_dao.get_recoverable_messages()
+        if not metas:
+            return []
+
+        recoverable: list[tuple[MessageMeta, float]] = []
+        for meta, status in metas:
+            if not meta.message or not meta.message.room:
+                logger.warning(
+                    'Recovery: meta %s has no message or room, skipping',
+                    meta.message_uuid,
+                )
+                continue
+
+            if status == DeliveryStatus.RETRYING.value:
+                retry_idx = min(
+                    int(meta.retry_count or 0), len(OUTBOUND_RETRY_DELAYS) - 1
+                )
+                delay = float(OUTBOUND_RETRY_DELAYS[retry_idx])
+            else:
+                delay = 0.0
+
+            recoverable.append((meta, delay))
+
+        logger.info('Recovery: %d message(s) to re-enqueue', len(recoverable))
+        return recoverable
+
+    async def execute(
+        self,
+        outbound: OutboundMessage,
+        delivery: MessageMeta,
+        tenant_uuid: str = '',
+    ) -> None:
+        backend = str(delivery.backend)
+        last_status = DeliveryStatus.PENDING
+        connector = await self._find_connector(backend, tenant_uuid)
+        if connector is None:
+            last_status = DeliveryStatus.DEAD_LETTER
+            last_record = await self._add_record(
+                delivery,
+                last_status,
+                reason=f'Backend {backend!r} not available',
+            )
+        else:
+            await self._add_record(delivery, DeliveryStatus.SENDING)
+
+            try:
+                external_id = await self._send(connector, outbound)
+                delivery.external_id = external_id  # type: ignore[assignment]
+                last_status = DeliveryStatus.SENT
+                last_record = await self._add_record(delivery, last_status)
+
+            except Exception as exc:
+                if not isinstance(exc, ConnectorSendError):
+                    logger.exception(
+                        'Unexpected error sending message %s via %s',
+                        outbound.message_uuid,
+                        backend,
+                    )
+
+                delivery.retry_count += 1  # type: ignore[assignment]
+                last_status = DeliveryStatus.FAILED
+                await self._add_record(
+                    delivery,
+                    last_status,
+                    reason=str(exc),
+                )
+
+                if delivery.retry_count >= OUTBOUND_MAX_RETRIES:  # type: ignore[operator]
+                    last_status = DeliveryStatus.DEAD_LETTER
+                    last_record = await self._add_record(
+                        delivery,
+                        last_status,
+                        reason=f'Max retries ({OUTBOUND_MAX_RETRIES}) exceeded',
+                    )
+                else:
+                    last_status = DeliveryStatus.RETRYING
+                    last_record = await self._add_record(delivery, last_status)
+
+        await self._notifier.delivery_status_updated(
+            delivery, last_record, delivery.message.room
+        )
+
+    async def _find_connector(self, backend: str, tenant_uuid: str) -> Connector | None:
+        """Find a connector instance, refreshing the cache if needed."""
+        connector = self._store.find_by_backend(backend, tenant_uuid)
+        if connector:
+            return connector
+
+        return await self._store.refresh(backend, tenant_uuid)
+
+    async def _send(
+        self,
+        connector: Connector,
+        outbound: OutboundMessage,
+    ) -> str:
+        """Call connector.send(), wrapping sync implementations."""
+        if inspect.iscoroutinefunction(connector.send):
+            return await connector.send(outbound)  # type: ignore[misc]
+        return await asyncio.to_thread(connector.send, outbound)
+
+    async def _add_record(
+        self,
+        delivery: MessageMeta,
+        status: DeliveryStatus,
+        reason: str | None = None,
+    ) -> DeliveryRecord:
+        record = DeliveryRecord(
+            status=status.value,
+            reason=reason,
+        )
+        await self._room_dao.add_delivery_record(delivery, record)
+        return record

--- a/wazo_chatd/plugins/connectors/loop.py
+++ b/wazo_chatd/plugins/connectors/loop.py
@@ -20,7 +20,6 @@ from wazo_chatd.bus import BusPublisher
 from wazo_chatd.database.async_helpers import (
     async_session_scope,
     init_async_db,
-    parse_ssl_from_uri,
 )
 from wazo_chatd.database.queries.async_.user_identity import AsyncUserIdentityDAO
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict
@@ -226,13 +225,12 @@ class DeliveryLoop:
 
     async def _listen_for_deliveries(self) -> None:
         assert self._shutdown is not None
-        ssl = parse_ssl_from_uri(self._db_uri)
         backoff = _backoff()
 
         while not self._shutdown.done():
             connection: asyncpg.Connection | None = None
             try:
-                connection = await asyncpg.connect(self._db_uri, ssl=ssl)
+                connection = await asyncpg.connect(self._db_uri)
                 await connection.add_listener(
                     'connector_delivery', self._on_delivery_notify
                 )

--- a/wazo_chatd/plugins/connectors/loop.py
+++ b/wazo_chatd/plugins/connectors/loop.py
@@ -1,0 +1,383 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import asyncio
+import itertools
+import logging
+import threading
+import time
+from collections.abc import Coroutine
+from types import TracebackType
+from typing import Any
+
+import asyncpg
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import StaleDataError
+
+from wazo_chatd.bus import BusPublisher
+from wazo_chatd.database.async_helpers import (
+    async_session_scope,
+    init_async_db,
+    parse_ssl_from_uri,
+)
+from wazo_chatd.database.queries.async_.user_identity import AsyncUserIdentityDAO
+from wazo_chatd.plugin_helpers.dependencies import ConfigDict
+from wazo_chatd.plugins.connectors.executor import DeliveryExecutor
+from wazo_chatd.plugins.connectors.notifier import AsyncNotifier
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.store import ConnectorStore
+from wazo_chatd.plugins.connectors.types import InboundMessage, StatusUpdate
+
+logger = logging.getLogger(__name__)
+
+
+def _backoff() -> itertools.chain[int]:
+    return itertools.chain([1, 2, 4, 8, 16, 32], itertools.repeat(32))
+
+
+class DeliveryLoop:
+    def __init__(
+        self,
+        config: ConfigDict,
+        registry: ConnectorRegistry,
+        store: ConnectorStore,
+    ) -> None:
+        self._config = config
+        self._registry = registry
+        self._store = store
+        self._max_tasks = int(config['delivery']['max_concurrent_tasks'])
+
+        self._db_uri = str(config.get('db_uri', ''))
+        engine, session_factory = init_async_db(self._db_uri)
+        self._engine = engine
+        self._session_factory = session_factory
+
+        bus_publisher = BusPublisher.from_config(
+            service_uuid=config.get('uuid', ''),
+            bus_config=config.get('bus', {}),
+        )
+        self._executor = DeliveryExecutor(
+            config=config,
+            registry=registry,
+            notifier=AsyncNotifier(bus_publisher),
+            store=store,
+        )
+
+        self._backoff = _backoff()
+        self._healthy: bool = False
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._shutdown: asyncio.Future[None] | None = None
+        self._thread: threading.Thread | None = None
+        self._in_flight: set[asyncio.Task[None]] = set()
+        self._semaphore: asyncio.Semaphore | None = None
+        self._listener_task: asyncio.Task[None] | None = None
+        self._restart_count: int = 0
+
+    def _init_loop(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        self._semaphore = asyncio.Semaphore(self._max_tasks)
+        self._shutdown = self._loop.create_future()
+
+    def __enter__(self) -> DeliveryLoop:
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.shutdown()
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None:
+            raise RuntimeError('DeliveryLoop has not been started')
+        return self._loop
+
+    @property
+    def semaphore(self) -> asyncio.Semaphore:
+        if self._semaphore is None:
+            raise RuntimeError('DeliveryLoop has not been started')
+        return self._semaphore
+
+    def start(self) -> None:
+        logger.info('Starting delivery loop')
+        self._init_loop()
+
+        self._thread = threading.Thread(
+            target=self._run_loop,
+            name='delivery-loop',
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info('Delivery loop started')
+
+    def shutdown(self, timeout: float = 10) -> None:
+        logger.info('Stopping delivery loop')
+
+        if self._loop and self._loop.is_running():
+            future = asyncio.run_coroutine_threadsafe(
+                self._drain_and_stop(), self._loop
+            )
+            future.result(timeout=timeout)
+
+        if self._thread:
+            self._thread.join(timeout=timeout)
+
+        logger.info('Delivery loop stopped')
+
+    def enqueue_message(
+        self,
+        message: InboundMessage | StatusUpdate,
+        delay: float | None = None,
+    ) -> None:
+        if delay:
+            self.loop.call_soon_threadsafe(
+                self.loop.call_later, delay, self._schedule_task, message
+            )
+        else:
+            self.loop.call_soon_threadsafe(self._schedule_task, message)
+
+    @property
+    def is_running(self) -> bool:
+        loop_running = self._loop is not None and self._loop.is_running()
+        thread_running = self._thread is not None and self._thread.is_alive()
+        return loop_running and thread_running
+
+    @property
+    def in_flight_count(self) -> int:
+        return len(self._in_flight)
+
+    @property
+    def restart_count(self) -> int:
+        return self._restart_count
+
+    def _run_loop(self) -> None:
+        loop = self._loop
+        assert loop is not None
+
+        asyncio.set_event_loop(loop)
+        loop.create_task(self._startup())
+        try:
+            loop.run_forever()
+        except Exception:
+            logger.exception('Delivery loop crashed, restarting')
+            self._teardown_loop(loop)
+            self._restart()
+            return
+
+        self._teardown_loop(loop)
+
+    async def _startup(self) -> None:
+        await self._populate_store()
+        await self._recover()
+        self._listener_task = asyncio.ensure_future(self._listen_for_deliveries())
+
+    async def _populate_store(self) -> None:
+        try:
+            async with async_session_scope(self._session_factory):
+                dao = AsyncUserIdentityDAO()
+                tenant_backends = await dao.list_tenant_backends()
+        except Exception:
+            logger.exception('Failed to scan tenant backends for store population')
+            return
+
+        sem = asyncio.Semaphore(20)
+
+        async def _load(backend: str, tenant_uuid: str) -> None:
+            async with sem:
+                await self._store.refresh(backend, tenant_uuid)
+
+        await asyncio.gather(
+            *(_load(backend, tenant_uuid) for tenant_uuid, backend in tenant_backends)
+        )
+
+        logger.info('Populated connector store with %d instance(s)', len(self._store))
+
+    def _teardown_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        if self._in_flight:
+            logger.warning('%d in-flight task(s) dropped', len(self._in_flight))
+            self._in_flight.clear()
+
+        if not loop.is_closed():
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
+
+    def _restart(self) -> None:
+        if self._healthy:
+            self._backoff = _backoff()
+            self._healthy = False
+
+        delay = next(self._backoff)
+        self._restart_count += 1
+        logger.warning(
+            'Restarting delivery loop in %ds (attempt #%d)',
+            delay,
+            self._restart_count,
+        )
+        time.sleep(delay)
+
+        self._init_loop()
+        self._run_loop()
+
+    async def _listen_for_deliveries(self) -> None:
+        assert self._shutdown is not None
+        ssl = parse_ssl_from_uri(self._db_uri)
+        backoff = _backoff()
+
+        while not self._shutdown.done():
+            connection: asyncpg.Connection | None = None
+            try:
+                connection = await asyncpg.connect(self._db_uri, ssl=ssl)
+                await connection.add_listener(
+                    'connector_delivery', self._on_delivery_notify
+                )
+                logger.info('Listening for connector_delivery notifications')
+                backoff = _backoff()
+
+                await self._shutdown
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                delay = next(backoff)
+                logger.exception('Listener connection lost, reconnecting in %ds', delay)
+                await asyncio.sleep(delay)
+            finally:
+                if connection and not connection.is_closed():
+                    await connection.close()
+
+        logger.info('Stopped listening for connector_delivery notifications')
+
+    def _on_delivery_notify(
+        self,
+        connection: asyncpg.Connection,
+        pid: int,
+        channel: str,
+        payload: str,
+    ) -> None:
+        message_uuid = payload
+        logger.debug('Received delivery notification for message %s', message_uuid)
+        self._schedule_outbound_notification(message_uuid)
+
+    def _schedule_outbound_notification(self, message_uuid: str) -> None:
+        assert self._loop is not None
+        task = self._loop.create_task(self._process_outbound_notification(message_uuid))
+        self._in_flight.add(task)
+        task.add_done_callback(self._task_done)
+
+    async def _process_outbound_notification(self, message_uuid: str) -> None:
+        async with self.semaphore:
+            try:
+                async with async_session_scope(self._session_factory):
+                    meta = await self._executor._room_dao.get_message_meta(message_uuid)
+                    if not meta:
+                        logger.error(
+                            'No MessageMeta found for notified message %s',
+                            message_uuid,
+                        )
+                        return
+
+                    if not meta.message or not meta.message.room:
+                        logger.warning(
+                            'Message %s or its room was deleted before delivery',
+                            message_uuid,
+                        )
+                        return
+
+                    await self._executor.route_outbound(meta)
+            except (StaleDataError, IntegrityError):
+                logger.warning(
+                    'Message %s was deleted during delivery, skipping',
+                    message_uuid,
+                )
+            except Exception:
+                logger.exception(
+                    'Failed to process delivery notification for %s', message_uuid
+                )
+
+    async def _recover(self) -> None:
+        try:
+            async with async_session_scope(self._session_factory):
+                recoverable = await self._executor.recover_pending_deliveries()
+        except Exception:
+            logger.exception('Recovery scan failed, continuing without recovery')
+            return
+
+        assert self._loop is not None
+        for meta, delay in recoverable:
+            message_uuid = str(meta.message_uuid)
+
+            if delay > 0:
+                logger.info(
+                    'Recovery: re-enqueuing %s with %.0fs delay',
+                    message_uuid,
+                    delay,
+                )
+                self._loop.call_later(
+                    delay, self._schedule_outbound_notification, message_uuid
+                )
+            else:
+                logger.info('Recovery: re-enqueuing %s immediately', message_uuid)
+                self._schedule_outbound_notification(message_uuid)
+
+    def _schedule_task(self, message: InboundMessage | StatusUpdate) -> None:
+        assert self._loop is not None
+
+        match message:
+            case InboundMessage():
+                coro = self._executor.route_inbound(message)
+            case StatusUpdate():
+                coro = self._executor.route_status_update(message)
+            case _:
+                return
+
+        task = self._loop.create_task(self._process(coro, message))
+        self._in_flight.add(task)
+        task.add_done_callback(self._task_done)
+
+    def _task_done(self, task: asyncio.Task[None]) -> None:
+        self._in_flight.discard(task)
+        if task.exception() is None:
+            self._healthy = True
+
+    async def _process(
+        self,
+        coro: Coroutine[Any, Any, None],
+        message: InboundMessage | StatusUpdate,
+    ) -> None:
+        async with self.semaphore:
+            logger.debug('Processing %s', message)
+            try:
+                async with async_session_scope(self._session_factory):
+                    await coro
+            except Exception:
+                logger.exception('Failed to process %s', message)
+
+    async def _drain_and_stop(self) -> None:
+        if self._shutdown and not self._shutdown.done():
+            self._shutdown.set_result(None)
+
+        if self._listener_task and not self._listener_task.done():
+            self._listener_task.cancel()
+            try:
+                await self._listener_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._in_flight:
+            logger.info(
+                'Waiting for %d in-flight task(s) to complete',
+                len(self._in_flight),
+            )
+            await asyncio.gather(*self._in_flight, return_exceptions=True)
+
+        if self._engine:
+            await self._engine.dispose()
+            logger.debug('Async database engine disposed')
+
+        assert self._loop is not None
+        self._loop.stop()

--- a/wazo_chatd/plugins/connectors/notifier.py
+++ b/wazo_chatd/plugins/connectors/notifier.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from wazo_bus.resources.chatd.events import (
+    MessageDeliveryStatusEvent,
+    UserIdentityCreatedEvent,
+    UserIdentityDeletedEvent,
+    UserIdentityUpdatedEvent,
+    UserRoomMessageCreatedEvent,
+)
+from wazo_bus.resources.chatd.types import DeliveryStatusDict, MessageDict
+from wazo_bus.resources.common.event import ServiceEvent
+
+from wazo_chatd.database.delivery import DeliveryStatus
+from wazo_chatd.database.models import (
+    DeliveryRecord,
+    MessageMeta,
+    Room,
+    RoomMessage,
+    UserIdentity,
+)
+from wazo_chatd.plugins.connectors.schemas import UserIdentitySchema
+
+if TYPE_CHECKING:
+    from wazo_chatd.bus import BusPublisher
+
+logger = logging.getLogger(__name__)
+
+
+class UserIdentityNotifier:
+    def __init__(self, bus_publisher: BusPublisher) -> None:
+        self._bus = bus_publisher
+
+    def created(self, identity: UserIdentity) -> None:
+        identity_data = UserIdentitySchema().dump(identity)
+        event = UserIdentityCreatedEvent(
+            identity_data, str(identity.tenant_uuid), str(identity.user_uuid)
+        )
+        self._bus.publish(event)
+
+    def updated(self, identity: UserIdentity) -> None:
+        identity_data = UserIdentitySchema().dump(identity)
+        event = UserIdentityUpdatedEvent(
+            identity_data, str(identity.tenant_uuid), str(identity.user_uuid)
+        )
+        self._bus.publish(event)
+
+    def deleted(self, identity: UserIdentity) -> None:
+        identity_data = UserIdentitySchema().dump(identity)
+        event = UserIdentityDeletedEvent(
+            identity_data, str(identity.tenant_uuid), str(identity.user_uuid)
+        )
+        self._bus.publish(event)
+
+
+class AsyncNotifier:
+    def __init__(self, bus_publisher: BusPublisher) -> None:
+        self._bus = bus_publisher
+
+    async def message_created(self, room: Room, message: RoomMessage) -> None:
+        message_data = self._build_message_payload(message)
+        for user in room.users:
+            event = UserRoomMessageCreatedEvent(
+                message_data, room.uuid, room.tenant_uuid, user.uuid
+            )
+            await self._publish(event)
+
+    async def delivery_status_updated(
+        self,
+        meta: MessageMeta,
+        record: DeliveryRecord,
+        room: Room,
+    ) -> None:
+        delivery_data: DeliveryStatusDict = {
+            'message_uuid': str(meta.message_uuid),
+            'status': str(record.status),
+            'timestamp': record.timestamp.isoformat(),
+            'backend': str(meta.backend),
+        }
+        event = MessageDeliveryStatusEvent(
+            delivery_data=delivery_data,
+            room_uuid=str(room.uuid),
+            message_uuid=str(meta.message_uuid),
+            tenant_uuid=str(room.tenant_uuid),
+            user_uuids=[str(u.uuid) for u in room.users],
+        )
+        await self._publish(event)
+
+        if record.status == DeliveryStatus.DELIVERED.value:
+            await self._notify_message_delivered(meta, room)
+
+    @staticmethod
+    def _build_message_payload(
+        message: RoomMessage, status_override: str | None = None
+    ) -> MessageDict:
+        meta = message.meta
+        return {
+            'uuid': str(message.uuid),
+            'content': message.content,
+            'alias': message.alias,
+            'delivery': {
+                'type': meta.type_,
+                'backend': meta.backend,
+                'status': status_override or meta.status,
+            },
+            'user_uuid': str(message.user_uuid),
+            'tenant_uuid': str(message.tenant_uuid),
+            'wazo_uuid': str(message.wazo_uuid),
+            'created_at': message.created_at.isoformat(),
+            'room': {'uuid': str(message.room.uuid)},
+        }
+
+    async def _notify_message_delivered(self, meta: MessageMeta, room: Room) -> None:
+        message = meta.message
+        sender_uuid = str(message.user_uuid)
+        recipients = [
+            u for u in room.users if not u.identity and str(u.uuid) != sender_uuid
+        ]
+        if not recipients:
+            return
+
+        message_data = self._build_message_payload(
+            message, status_override=DeliveryStatus.DELIVERED.value
+        )
+        for user in recipients:
+            event = UserRoomMessageCreatedEvent(
+                message_data, room.uuid, room.tenant_uuid, user.uuid
+            )
+            await self._publish(event)
+
+    async def _publish(self, event: ServiceEvent) -> None:
+        try:
+            await asyncio.to_thread(self._bus.publish, event)
+        except Exception:
+            logger.exception('Failed to publish bus event %s', event.name)

--- a/wazo_chatd/plugins/connectors/router.py
+++ b/wazo_chatd/plugins/connectors/router.py
@@ -1,0 +1,132 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from flask_restful import Api
+
+from wazo_chatd.plugin_helpers.dependencies import ConfigDict, MessageContext
+from wazo_chatd.plugins.connectors.exceptions import (
+    ConnectorParseError,
+    MessageIdentityRequiredError,
+)
+from wazo_chatd.plugins.connectors.http import ConnectorWebhookResource
+from wazo_chatd.plugins.connectors.loop import DeliveryLoop
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.services import ConnectorService
+from wazo_chatd.plugins.connectors.store import ConnectorStore
+from wazo_chatd.plugins.connectors.types import WebhookData
+
+if TYPE_CHECKING:
+    from wazo_auth_client import Client as AuthClient
+
+    from wazo_chatd.database.models import Room
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectorRouter:
+    """Main entry point for the connector subsystem.
+
+    Owns the delivery loop, manages connector instances, handles
+    capability resolution and message forwarding.  Heavy processing
+    (identity lookup, delivery tracking, persistence) happens
+    asynchronously in the delivery loop.
+    """
+
+    def __init__(
+        self,
+        config: ConfigDict,
+        registry: ConnectorRegistry,
+        service: ConnectorService,
+        auth_client: AuthClient,
+    ) -> None:
+        self._registry = registry
+        self._service = service
+        connectors_config = config.get('connectors') or {}
+        delivery_config = config.get('delivery') or {}
+        self._store = ConnectorStore(
+            auth_client,
+            registry,
+            cache_ttl=float(delivery_config.get('provider_cache_ttl', 300)),
+            connectors_config=connectors_config,
+        )
+        self._delivery_loop = DeliveryLoop(config, registry, self._store)
+
+    def register_http_endpoints(self, api: Api) -> None:
+        api.add_resource(
+            ConnectorWebhookResource,
+            '/connectors/incoming',
+            '/connectors/incoming/<backend>',
+            resource_class_args=[self],
+        )
+
+    def start(self) -> None:
+        self._delivery_loop.start()
+
+    def stop(self) -> None:
+        self._delivery_loop.shutdown()
+
+    def validate_room_creation(self, room: Room) -> None:
+        self._service.validate_room_reachability(room)
+
+    def prepare_outbound(self, context: MessageContext) -> None:
+        has_external = any(u.identity for u in context.room.users)
+        if has_external and not context.sender_identity_uuid:
+            raise MessageIdentityRequiredError()
+
+        if context.sender_identity_uuid:
+            identity = self._service.validate_identity_reachability(
+                context.room,
+                str(context.message.user_uuid),
+                context.sender_identity_uuid,
+            )
+            context.resolved_sender_identity = identity
+            self._service.prepare_outbound_delivery(context.message, identity)
+
+    def provide_status(self, status: dict[str, dict[str, str | int]]) -> None:
+        loop = self._delivery_loop
+        is_running = loop.is_running
+        status['connectors'] = {
+            'status': 'ok' if is_running else 'fail',
+            'in_flight': loop.in_flight_count,
+            'restart_count': loop.restart_count,
+            'instances': len(self._store),
+        }
+
+    def dispatch_webhook(
+        self,
+        data: WebhookData,
+        backend: str | None = None,
+    ) -> None:
+        """Parse an incoming webhook and enqueue the result.
+
+        Uses backend classes from the registry directly — inbound parsing
+        is stateless (no auth config needed).  The store is only required
+        for the outbound ``send()`` path.
+
+        Raises:
+            ConnectorParseError: If no connector can handle the webhook.
+        """
+        backends = self._registry.available_backends()
+        if not backends:
+            raise ConnectorParseError('No connector backends registered')
+
+        if backend and backend in backends:
+            ordered = [backend] + [b for b in backends if b != backend]
+        else:
+            ordered = backends
+
+        for name in ordered:
+            cls = self._registry.get_backend(name)
+            if not cls.can_handle(data):
+                continue
+            result = cls.on_event(data)
+            if result is not None:
+                self._delivery_loop.enqueue_message(result)
+                return
+
+        raise ConnectorParseError('No connector matched the webhook payload')

--- a/wazo_chatd/plugins/connectors/tests/test_bus_consume.py
+++ b/wazo_chatd/plugins/connectors/tests/test_bus_consume.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from wazo_chatd.plugins.connectors.bus_consume import ConnectorBusEventHandler
+
+
+class TestConnectorBusEventHandler(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus_consumer = Mock()
+        self.router = Mock()
+        self.handler = ConnectorBusEventHandler(self.bus_consumer, self.router)
+
+    def test_subscribe_is_noop(self) -> None:
+        self.handler.subscribe()
+
+        self.bus_consumer.subscribe.assert_not_called()

--- a/wazo_chatd/plugins/connectors/tests/test_events.py
+++ b/wazo_chatd/plugins/connectors/tests/test_events.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+
+from wazo_bus.resources.chatd.events import MessageDeliveryStatusEvent
+
+
+class TestMessageDeliveryStatusEvent(unittest.TestCase):
+    def test_event_name(self) -> None:
+        event = MessageDeliveryStatusEvent(
+            delivery_data={'status': 'sent', 'message_uuid': 'msg-1'},
+            tenant_uuid='tenant-1',
+            user_uuids=['user-1'],
+            room_uuid='room-1',
+            message_uuid='msg-1',
+        )
+
+        assert event.name == 'chatd_message_delivery_status'
+
+    def test_routing_key(self) -> None:
+        event = MessageDeliveryStatusEvent(
+            delivery_data={'status': 'sent', 'message_uuid': 'msg-1'},
+            tenant_uuid='tenant-1',
+            user_uuids=['user-1'],
+            room_uuid='room-1',
+            message_uuid='msg-1',
+        )
+
+        assert event.routing_key == 'chatd.rooms.room-1.messages.msg-1.delivery'
+
+    def test_content_is_delivery_data(self) -> None:
+        data = {'status': 'failed', 'message_uuid': 'msg-1', 'reason': 'timeout'}
+        event = MessageDeliveryStatusEvent(
+            delivery_data=data,
+            tenant_uuid='tenant-1',
+            user_uuids=['user-1', 'user-2'],
+            room_uuid='room-1',
+            message_uuid='msg-1',
+        )
+
+        assert event.content == data

--- a/wazo_chatd/plugins/connectors/tests/test_executor.py
+++ b/wazo_chatd/plugins/connectors/tests/test_executor.py
@@ -1,0 +1,696 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import time
+import unittest
+from collections.abc import Callable, Mapping
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+from unittest.mock import AsyncMock, Mock
+
+from wazo_chatd.database.async_helpers import _current_session
+from wazo_chatd.database.delivery import DeliveryStatus
+from wazo_chatd.plugins.connectors.exceptions import ConnectorSendError
+from wazo_chatd.plugins.connectors.executor import (
+    OUTBOUND_MAX_RETRIES,
+    DeliveryExecutor,
+    generate_message_signature,
+)
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.store import ConnectorStore
+from wazo_chatd.plugins.connectors.types import (
+    InboundMessage,
+    OutboundMessage,
+    StatusUpdate,
+    TransportData,
+)
+
+FIXED_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _mock_add_delivery_record() -> AsyncMock:
+    async def _side_effect(meta, record):
+        record.message_uuid = meta.message_uuid
+        record.timestamp = FIXED_NOW
+        return record
+
+    return AsyncMock(side_effect=_side_effect)
+
+
+def _make_outbound(message_uuid: str = 'delivery-1') -> OutboundMessage:
+    return OutboundMessage(
+        room_uuid='room-uuid',
+        message_uuid=message_uuid,
+        sender_uuid='user-uuid',
+        body='hello',
+        message_type='sms',
+        sender_identity='+15551234',
+        recipient_identity='+15559876',
+        metadata={'idempotency_key': 'key-1'},
+    )
+
+
+class _FakeConnector:
+    backend: ClassVar[str] = 'twilio'
+    supported_types: ClassVar[tuple[str, ...]] = ('sms',)
+    status_map: ClassVar[dict[str, DeliveryStatus]] = {}
+
+    def __init__(
+        self,
+        provider_config: Mapping[str, Any] | None = None,
+        connector_config: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.send_return = 'ext-msg-id-123'
+        self.send_side_effect: Exception | None = None
+
+    def send(self, message: OutboundMessage) -> str:
+        if self.send_side_effect:
+            raise self.send_side_effect
+        return self.send_return
+
+    @classmethod
+    def can_handle(cls, data: TransportData) -> bool:
+        return True
+
+    @classmethod
+    def on_event(cls, data: TransportData) -> InboundMessage | StatusUpdate | None:
+        return None
+
+    def listen(self, on_message: Callable[[InboundMessage], None]) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    @classmethod
+    def normalize_identity(cls, raw_identity: str) -> str:
+        return raw_identity
+
+
+class TestDeliveryExecutorExecute(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.session = AsyncMock()
+        self.session.add = Mock()
+        self.token = _current_session.set(self.session)
+
+        self.registry = Mock()
+        self.connector = _FakeConnector()
+        self.notifier = AsyncMock()
+        self.executor = DeliveryExecutor(
+            config={'uuid': 'test-wazo-uuid'},
+            registry=self.registry,
+            notifier=self.notifier,
+            store=ConnectorStore(Mock(), ConnectorRegistry()),
+        )
+        self.executor._store._cache[('tenant-uuid', 'twilio')] = self.connector
+        self.executor._store._timestamps[('tenant-uuid', 'twilio')] = time.monotonic()
+        self.executor._room_dao.add_delivery_record = _mock_add_delivery_record()
+
+        self.delivery = Mock()
+        self.delivery.message_uuid = 'delivery-1'
+        self.delivery.backend = 'twilio'
+        self.delivery.retry_count = 0
+        self.delivery.external_id = None
+        self.delivery.records = []
+        self.delivery.message = Mock(
+            room=Mock(
+                uuid='room-uuid', tenant_uuid='tenant-uuid', users=[Mock(uuid='user-1')]
+            )
+        )
+
+    def tearDown(self) -> None:
+        _current_session.reset(self.token)
+
+    async def test_execute_success(self) -> None:
+        outbound = _make_outbound()
+
+        await self.executor.execute(outbound, self.delivery, tenant_uuid='tenant-uuid')
+
+        assert self.delivery.external_id == 'ext-msg-id-123'
+
+    async def test_execute_failure_increments_retry(self) -> None:
+        self.connector.send_side_effect = ConnectorSendError('timeout')
+        outbound = _make_outbound()
+
+        await self.executor.execute(outbound, self.delivery, tenant_uuid='tenant-uuid')
+
+        assert self.delivery.retry_count == 1
+
+    async def test_execute_max_retries_sets_dead_letter(self) -> None:
+        self.connector.send_side_effect = ConnectorSendError('timeout')
+        self.delivery.retry_count = OUTBOUND_MAX_RETRIES - 1
+        outbound = _make_outbound()
+
+        await self.executor.execute(outbound, self.delivery, tenant_uuid='tenant-uuid')
+
+        dao_mock = self.executor._room_dao.add_delivery_record
+        statuses = [call.args[1].status for call in dao_mock.call_args_list]
+        assert DeliveryStatus.DEAD_LETTER.value in statuses
+
+    async def test_execute_publishes_status_event(self) -> None:
+        outbound = _make_outbound()
+
+        await self.executor.execute(outbound, self.delivery, tenant_uuid='tenant-uuid')
+
+        self.notifier.delivery_status_updated.assert_awaited_once()
+
+    async def test_execute_unexpected_error_treated_as_failure(self) -> None:
+        self.connector.send_side_effect = RuntimeError('SDK crashed')
+        outbound = _make_outbound()
+
+        await self.executor.execute(outbound, self.delivery, tenant_uuid='tenant-uuid')
+
+        assert self.delivery.retry_count == 1
+        dao_mock = self.executor._room_dao.add_delivery_record
+        statuses = [call.args[1].status for call in dao_mock.call_args_list]
+        assert DeliveryStatus.FAILED.value in statuses
+
+
+class TestDeliveryExecutorRouteOutbound(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.session = AsyncMock()
+        self.session.add = Mock()
+        self.token = _current_session.set(self.session)
+
+        self.registry = Mock()
+        self.registry.resolve_reachable_types.return_value = {'sms'}
+
+        self.connector = _FakeConnector()
+        self.store = ConnectorStore(Mock(), ConnectorRegistry())
+        self.executor = DeliveryExecutor(
+            config={'uuid': 'test-wazo-uuid'},
+            registry=self.registry,
+            notifier=AsyncMock(),
+            store=self.store,
+        )
+        self.store._cache[('tenant-uuid', 'twilio')] = self.connector
+        self.store._timestamps[('tenant-uuid', 'twilio')] = time.monotonic()
+        self.executor._room_dao.add_delivery_record = _mock_add_delivery_record()
+
+    def tearDown(self) -> None:
+        _current_session.reset(self.token)
+
+    async def test_route_outbound_resolves_identity_and_sends(self) -> None:
+        sender_identity = Mock(
+            identity='+15551234',
+            tenant_uuid='tenant-uuid',
+            backend='twilio',
+            type_='sms',
+        )
+        recipient_user = Mock(uuid='recipient-uuid', identity=None)
+        sender_user = Mock(uuid='sender-uuid', identity=None)
+        room = Mock(uuid='room-uuid', users=[sender_user, recipient_user])
+        message = Mock(uuid='msg-uuid', user_uuid='sender-uuid', content='hello')
+
+        meta = Mock()
+        meta.message_uuid = 'msg-uuid'
+        meta.sender_identity = sender_identity
+        meta.message = message
+        meta.message.room = room
+        meta.extra = {}
+
+        recipient_identity = Mock(identity='+15559876')
+        self.executor._user_identity_dao.list_by_user = AsyncMock(
+            return_value=[recipient_identity]
+        )
+
+        await self.executor.route_outbound(meta)
+
+        assert meta.extra['outbound_idempotency_key'] == 'msg-uuid'
+
+
+def _make_inbound(
+    idempotency_key: str | None = None,
+) -> InboundMessage:
+    metadata: dict[str, str] = {}
+    if idempotency_key:
+        metadata['idempotency_key'] = idempotency_key
+    return InboundMessage(
+        sender='+15559876',
+        recipient='+15551234',
+        body='hello from outside',
+        backend='twilio',
+        message_type='sms',
+        external_id='ext-123',
+        metadata=metadata,
+    )
+
+
+class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.session = AsyncMock()
+        self.session.add = Mock()
+        self.token = _current_session.set(self.session)
+
+        self.registry = Mock()
+        self.registry.get_backend.side_effect = KeyError
+        self.notifier = AsyncMock()
+        self.executor = DeliveryExecutor(
+            config={'uuid': 'test-wazo-uuid'},
+            registry=self.registry,
+            notifier=self.notifier,
+            store=ConnectorStore(Mock(), ConnectorRegistry()),
+        )
+
+    def tearDown(self) -> None:
+        _current_session.reset(self.token)
+
+    async def test_route_inbound_dedup_skips_duplicate(self) -> None:
+        inbound = _make_inbound(idempotency_key='existing-key')
+
+        self.executor._room_dao.check_duplicate_idempotency_key = AsyncMock(
+            return_value=True
+        )
+
+        await self.executor.route_inbound(inbound)
+
+        self.session.add.assert_not_called()
+
+    async def test_route_inbound_no_dedup_key_skips_dedup_check(self) -> None:
+        inbound = _make_inbound()
+
+        self.executor._room_dao.check_duplicate_idempotency_key = AsyncMock()
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={}
+        )
+
+        await self.executor.route_inbound(inbound)
+
+        self.executor._room_dao.check_duplicate_idempotency_key.assert_not_awaited()
+
+    async def test_route_inbound_unknown_recipient_logs_and_returns(self) -> None:
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={}
+        )
+
+        await self.executor.route_inbound(inbound)
+
+        self.session.add.assert_not_called()
+
+    async def test_route_inbound_creates_message_and_meta(self) -> None:
+        recipient = Mock(uuid='wazo-user-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='wazo-user-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        self.executor._room_dao.add_message.assert_awaited_once()
+        message = self.executor._room_dao.add_message.call_args[0][1]
+        assert message.meta is not None
+        assert message.meta.backend == 'twilio'
+
+    async def test_route_inbound_publishes_message_event(self) -> None:
+        recipient = Mock(uuid='wazo-user-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='wazo-user-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        self.notifier.message_created.assert_awaited_once()
+
+    async def test_route_inbound_resolves_sender_to_wazo_user(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        sender = Mock(uuid='sender-wazo-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid'), Mock(uuid='sender-wazo-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient, '+15559876': sender}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.has_matching_signature = AsyncMock(return_value=False)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        call_args = self.executor._room_dao.find_or_create_room.call_args
+        participants = call_args.kwargs['participants']
+        sender_participant = [
+            p for p in participants if str(p.uuid) == 'sender-wazo-uuid'
+        ][0]
+        assert sender_participant.identity is None
+
+    async def test_route_inbound_unresolved_sender_stays_external(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        call_args = self.executor._room_dao.find_or_create_room.call_args
+        participants = call_args.kwargs['participants']
+        sender_participant = [p for p in participants if p.identity is not None][0]
+        assert sender_participant.identity == '+15559876'
+
+    async def test_route_inbound_echo_dropped(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        sender = Mock(uuid='sender-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid'), Mock(uuid='sender-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient, '+15559876': sender}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.has_matching_signature = AsyncMock(return_value=True)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        self.executor._room_dao.add_message.assert_not_awaited()
+        self.notifier.message_created.assert_not_awaited()
+
+    async def test_route_inbound_no_echo_creates_message(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        sender = Mock(uuid='sender-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid'), Mock(uuid='sender-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient, '+15559876': sender}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.has_matching_signature = AsyncMock(return_value=False)
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        self.executor._room_dao.add_message.assert_awaited_once()
+
+    async def test_route_inbound_retries_on_persist_failure(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.add_message = AsyncMock(
+            side_effect=[RuntimeError('DB down'), AsyncMock()]
+        )
+
+        await self.executor.route_inbound(inbound)
+
+        assert self.executor._room_dao.add_message.await_count == 2
+        self.notifier.message_created.assert_awaited_once()
+
+    async def test_route_inbound_external_sender_skips_dedup(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._user_identity_dao.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient}
+        )
+        self.executor._room_dao.find_or_create_room = AsyncMock(return_value=room)
+        self.executor._room_dao.has_matching_signature = AsyncMock()
+        self.executor._room_dao.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        self.executor._room_dao.has_matching_signature.assert_not_awaited()
+        self.executor._room_dao.add_message.assert_awaited_once()
+
+
+class TestGenerateMessageSignature(unittest.TestCase):
+    def test_basic(self) -> None:
+        fp = generate_message_signature('+15551234', 'Hello world')
+        assert isinstance(fp, str)
+        assert len(fp) == 16
+
+    def test_same_input_same_output(self) -> None:
+        fp1 = generate_message_signature('+15551234', 'Hello world')
+        fp2 = generate_message_signature('+15551234', 'Hello world')
+        assert fp1 == fp2
+
+    def test_whitespace_ignored(self) -> None:
+        fp1 = generate_message_signature('+15551234', 'Hello world')
+        fp2 = generate_message_signature('+15551234', 'Hello  world')
+        fp3 = generate_message_signature('+15551234', ' Hello world ')
+        assert fp1 == fp2 == fp3
+
+    def test_case_ignored(self) -> None:
+        fp1 = generate_message_signature('+15551234', 'Hello World')
+        fp2 = generate_message_signature('+15551234', 'hello world')
+        assert fp1 == fp2
+
+    def test_non_ascii_stripped(self) -> None:
+        fp1 = generate_message_signature('+15551234', 'Hello wörld 🎉')
+        fp2 = generate_message_signature('+15551234', 'Hello wörld 🎉')
+        assert fp1 == fp2
+
+    def test_different_sender_different_fingerprint(self) -> None:
+        fp1 = generate_message_signature('+15551234', 'ok')
+        fp2 = generate_message_signature('+15559876', 'ok')
+        assert fp1 != fp2
+
+    def test_capped_at_160_chars(self) -> None:
+        long_body = 'a' * 300
+        fp1 = generate_message_signature('+15551234', long_body)
+        fp2 = generate_message_signature('+15551234', 'a' * 160)
+        assert fp1 == fp2
+
+    def test_empty_body(self) -> None:
+        fp = generate_message_signature('+15551234', '')
+        assert isinstance(fp, str)
+        assert len(fp) == 16
+
+
+def _make_status_update(
+    external_id: str = 'ext-123',
+    status: str = 'delivered',
+    backend: str = 'test',
+    error_code: str = '',
+) -> StatusUpdate:
+    return StatusUpdate(
+        external_id=external_id,
+        status=status,
+        backend=backend,
+        error_code=error_code,
+    )
+
+
+class TestDeliveryExecutorRouteStatusUpdate(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.session = AsyncMock()
+        self.session.add = Mock()
+        self.token = _current_session.set(self.session)
+
+        self.registry = Mock()
+        self.store = ConnectorStore(Mock(), ConnectorRegistry())
+        self.notifier = AsyncMock()
+        self.executor = DeliveryExecutor(
+            config={'uuid': 'test-wazo-uuid'},
+            registry=self.registry,
+            notifier=self.notifier,
+            store=self.store,
+        )
+        self.executor._room_dao.add_delivery_record = _mock_add_delivery_record()
+
+    def tearDown(self) -> None:
+        _current_session.reset(self.token)
+
+    def _register_connector(self, status_map: dict) -> None:
+        backend_cls = Mock()
+        backend_cls.status_map = status_map
+        self.registry.get_backend.return_value = backend_cls
+
+    def _mock_meta(self) -> Mock:
+        meta = Mock()
+        meta.message_uuid = 'msg-uuid'
+        meta.message = Mock()
+        meta.message.room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        meta.message.room.users = [Mock(uuid='user-1')]
+        self.executor._room_dao.get_message_meta_by_external_id = AsyncMock(
+            return_value=meta
+        )
+        return meta
+
+    async def test_creates_delivery_record(self) -> None:
+        self._register_connector({'delivered': DeliveryStatus.DELIVERED})
+        self._mock_meta()
+
+        await self.executor.route_status_update(_make_status_update())
+
+        record = self.executor._room_dao.add_delivery_record.call_args[0][1]
+        assert record.status == 'delivered'
+
+    async def test_ignores_unmapped_status(self) -> None:
+        self._register_connector({'delivered': DeliveryStatus.DELIVERED})
+
+        await self.executor.route_status_update(_make_status_update(status='queued'))
+
+        self.executor._room_dao.add_delivery_record.assert_not_awaited()
+
+    async def test_drops_when_no_connector(self) -> None:
+        self.registry.get_backend.side_effect = KeyError('test')
+        await self.executor.route_status_update(_make_status_update())
+
+        self.executor._room_dao.add_delivery_record.assert_not_awaited()
+
+    async def test_drops_when_no_meta(self) -> None:
+        self._register_connector({'delivered': DeliveryStatus.DELIVERED})
+        self.executor._room_dao.get_message_meta_by_external_id = AsyncMock(
+            return_value=None
+        )
+
+        await self.executor.route_status_update(_make_status_update())
+
+        self.executor._room_dao.add_delivery_record.assert_not_awaited()
+
+    async def test_passes_error_code_as_reason(self) -> None:
+        self._register_connector({'failed': DeliveryStatus.FAILED})
+        self._mock_meta()
+
+        await self.executor.route_status_update(
+            _make_status_update(status='failed', error_code='30003')
+        )
+
+        record = self.executor._room_dao.add_delivery_record.call_args[0][1]
+        assert record.reason == '30003'
+
+    async def test_publishes_notification(self) -> None:
+        self._register_connector({'delivered': DeliveryStatus.DELIVERED})
+        self._mock_meta()
+
+        await self.executor.route_status_update(_make_status_update())
+
+        self.notifier.delivery_status_updated.assert_awaited_once()
+
+
+class TestDeliveryExecutorRecovery(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.session = AsyncMock()
+        self.token = _current_session.set(self.session)
+        self.executor = DeliveryExecutor(
+            config={'uuid': 'test-wazo-uuid'},
+            registry=Mock(),
+            notifier=AsyncMock(),
+            store=ConnectorStore(Mock(), ConnectorRegistry()),
+        )
+
+    def tearDown(self) -> None:
+        _current_session.reset(self.token)
+
+    def _make_meta(
+        self,
+        message_uuid: str = 'msg-1',
+        retry_count: int = 0,
+        extra: dict | None = None,
+    ) -> Mock:
+        user = Mock(uuid='user-uuid')
+        room = Mock(uuid='room-uuid')
+        room.users = [user, Mock(uuid='ext-uuid', identity='test:+1555')]
+        message = Mock(
+            uuid=message_uuid, user_uuid='user-uuid', content='hello', room=room
+        )
+        meta = Mock()
+        meta.message_uuid = message_uuid
+        meta.message = message
+        meta.retry_count = retry_count
+        meta.extra = extra or {}
+        return meta
+
+    async def test_no_recoverable_messages(self) -> None:
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(return_value=[])
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert result == []
+
+    async def test_pending_message_recovered_immediately(self) -> None:
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(
+            return_value=[(self._make_meta(), 'pending')]
+        )
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert len(result) == 1
+        outbound, delay = result[0]
+        assert outbound.message_uuid == 'msg-1'
+        assert delay == 0.0
+
+    async def test_retrying_message_recovered_with_delay(self) -> None:
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(
+            return_value=[(self._make_meta(retry_count=1), 'retrying')]
+        )
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert len(result) == 1
+        _, delay = result[0]
+        assert delay == 120.0
+
+    async def test_sending_recovered(self) -> None:
+        meta = self._make_meta()
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(
+            return_value=[(meta, 'sending')]
+        )
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert len(result) == 1
+        recovered_meta, delay = result[0]
+        assert recovered_meta is meta
+        assert delay == 0.0
+
+    async def test_skips_meta_with_no_message(self) -> None:
+        meta = self._make_meta()
+        meta.message = None
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(
+            return_value=[(meta, 'pending')]
+        )
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert result == []
+
+    async def test_skips_meta_with_no_room(self) -> None:
+        meta = self._make_meta()
+        meta.message.room = None
+        self.executor._room_dao.get_recoverable_messages = AsyncMock(
+            return_value=[(meta, 'pending')]
+        )
+
+        result = await self.executor.recover_pending_deliveries()
+
+        assert result == []

--- a/wazo_chatd/plugins/connectors/tests/test_loop.py
+++ b/wazo_chatd/plugins/connectors/tests/test_loop.py
@@ -1,0 +1,199 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import asyncio
+import time
+import unittest
+import unittest.mock
+from unittest.mock import AsyncMock, Mock
+
+from wazo_chatd.plugin_helpers.dependencies import ConfigDict
+from wazo_chatd.plugins.connectors.loop import DeliveryLoop
+from wazo_chatd.plugins.connectors.types import InboundMessage
+
+
+def _make_config() -> ConfigDict:
+    return {
+        'db_uri': 'postgresql://localhost/test',
+        'uuid': 'svc-uuid',
+        'bus': {},
+        'delivery': {'max_concurrent_tasks': 100},
+    }
+
+
+def _make_inbound() -> InboundMessage:
+    return InboundMessage(
+        sender='+15559876',
+        recipient='+15551234',
+        body='hello',
+        backend='twilio',
+        message_type='sms',
+        external_id='ext-123',
+    )
+
+
+def _mock_asyncpg_conn() -> AsyncMock:
+    conn = AsyncMock()
+    conn.is_closed = Mock(return_value=True)
+    return conn
+
+
+def _mock_session_factory() -> Mock:
+    result_mock = Mock()
+    result_mock.all.return_value = []
+    result_mock.scalars.return_value.all.return_value = []
+
+    session = AsyncMock()
+    session.execute.return_value = result_mock
+    return Mock(return_value=session)
+
+
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.asyncpg')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.init_async_db')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.BusPublisher')
+class TestDeliveryLoopLifecycle(unittest.TestCase):
+    def test_start_creates_loop_thread(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        mock_asyncpg.connect = AsyncMock(return_value=_mock_asyncpg_conn())
+
+        loop = DeliveryLoop(_make_config(), Mock(), Mock())
+        loop.start()
+
+        try:
+            assert loop._loop is not None
+            assert loop._loop.is_running()
+            assert loop._thread is not None
+            assert loop._thread.is_alive()
+        finally:
+            loop.shutdown()
+
+    def test_shutdown_stops_loop(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        mock_asyncpg.connect = AsyncMock(return_value=_mock_asyncpg_conn())
+
+        loop = DeliveryLoop(_make_config(), Mock(), Mock())
+        loop.start()
+        loop.shutdown(timeout=10)
+
+        assert loop._thread is not None
+        loop._thread.join(timeout=5)
+        assert not loop._thread.is_alive()
+
+    def test_context_manager(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        mock_asyncpg.connect = AsyncMock(return_value=_mock_asyncpg_conn())
+
+        with DeliveryLoop(_make_config(), Mock(), Mock()) as loop:
+            assert loop._loop is not None
+            assert loop._loop.is_running()
+
+        assert loop._thread is not None
+        assert not loop._thread.is_alive()
+
+
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.asyncpg')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.init_async_db')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.BusPublisher')
+class TestDeliveryLoopStatus(unittest.TestCase):
+    def test_is_running_when_started(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        mock_asyncpg.connect = AsyncMock(return_value=_mock_asyncpg_conn())
+
+        loop = DeliveryLoop(_make_config(), Mock(), Mock())
+        loop.start()
+
+        try:
+            assert loop.is_running is True
+        finally:
+            loop.shutdown()
+
+    def test_is_not_running_when_not_started(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+
+        loop = DeliveryLoop(_make_config(), Mock(), Mock())
+
+        assert loop.is_running is False
+
+
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.asyncpg')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.init_async_db')
+@unittest.mock.patch('wazo_chatd.plugins.connectors.loop.BusPublisher')
+class TestDeliveryLoopEnqueue(unittest.TestCase):
+    def test_enqueue_inbound_creates_task(
+        self, mock_bus: Mock, mock_init_db: Mock, mock_asyncpg: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        mock_asyncpg.connect = AsyncMock(return_value=_mock_asyncpg_conn())
+
+        with DeliveryLoop(_make_config(), Mock(), Mock()) as loop:
+            loop.enqueue_message(_make_inbound())
+            time.sleep(0.1)
+
+            assert loop._executor is not None
+
+
+class TestDeliveryLoopRestart(unittest.TestCase):
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.loop.init_async_db')
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.loop.BusPublisher')
+    def _make_loop(self, mock_bus: Mock, mock_init_db: Mock) -> DeliveryLoop:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        loop = DeliveryLoop(_make_config(), Mock(), Mock())
+        loop._loop = asyncio.new_event_loop()
+        loop._semaphore = asyncio.Semaphore(100)
+        return loop
+
+    def test_restart_increments_count(self) -> None:
+        loop = self._make_loop()
+        with unittest.mock.patch.object(loop, '_run_loop'):
+            with unittest.mock.patch('wazo_chatd.plugins.connectors.loop.time.sleep'):
+                loop._restart()
+                assert loop.restart_count == 1
+                loop._restart()
+                assert loop.restart_count == 2
+
+    def test_restart_backoff_increases(self) -> None:
+        loop = self._make_loop()
+        delays: list[int] = []
+        with unittest.mock.patch.object(loop, '_run_loop'):
+            with unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.loop.time.sleep',
+                side_effect=lambda d: delays.append(d),
+            ):
+                for _ in range(4):
+                    loop._restart()
+        assert delays == [1, 2, 4, 8]
+
+    def test_restart_resets_backoff_when_healthy(self) -> None:
+        loop = self._make_loop()
+        delays: list[int] = []
+        with unittest.mock.patch.object(loop, '_run_loop'):
+            with unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.loop.time.sleep',
+                side_effect=lambda d: delays.append(d),
+            ):
+                loop._restart()
+                loop._restart()
+                assert delays == [1, 2]
+
+                loop._healthy = True
+                loop._restart()
+                assert delays[-1] == 1

--- a/wazo_chatd/plugins/connectors/tests/test_notifier.py
+++ b/wazo_chatd/plugins/connectors/tests/test_notifier.py
@@ -1,0 +1,195 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+from wazo_chatd.plugins.connectors.notifier import AsyncNotifier, UserIdentityNotifier
+
+
+class TestUserIdentityNotifier(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus = Mock()
+        self.notifier = UserIdentityNotifier(self.bus)
+
+    def _make_identity(self) -> Mock:
+        identity = Mock()
+        identity.uuid = 'identity-uuid'
+        identity.user_uuid = 'user-uuid'
+        identity.tenant_uuid = 'tenant-uuid'
+        identity.backend = 'twilio'
+        identity.type_ = 'sms'
+        identity.identity = '+15551234567'
+        identity.extra = {}
+        return identity
+
+    def test_created_publishes_event(self) -> None:
+        identity = self._make_identity()
+
+        self.notifier.created(identity)
+
+        self.bus.publish.assert_called_once()
+        event = self.bus.publish.call_args[0][0]
+        assert event.name == 'chatd_user_identity_created'
+        assert event.content['uuid'] == 'identity-uuid'
+        assert event.content['backend'] == 'twilio'
+        assert event.content['type'] == 'sms'
+        assert event.content['identity'] == '+15551234567'
+
+    def test_updated_publishes_event(self) -> None:
+        identity = self._make_identity()
+
+        self.notifier.updated(identity)
+
+        self.bus.publish.assert_called_once()
+        event = self.bus.publish.call_args[0][0]
+        assert event.name == 'chatd_user_identity_updated'
+
+    def test_deleted_publishes_event(self) -> None:
+        identity = self._make_identity()
+
+        self.notifier.deleted(identity)
+
+        self.bus.publish.assert_called_once()
+        event = self.bus.publish.call_args[0][0]
+        assert event.name == 'chatd_user_identity_deleted'
+        assert event.content['uuid'] == 'identity-uuid'
+
+    def test_event_targets_correct_user(self) -> None:
+        identity = self._make_identity()
+
+        self.notifier.created(identity)
+
+        event = self.bus.publish.call_args[0][0]
+        assert event.user_uuid == 'user-uuid'
+        assert event.tenant_uuid == 'tenant-uuid'
+
+
+class TestAsyncNotifierMessageCreated(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.bus = Mock()
+        self.notifier = AsyncNotifier(self.bus)
+
+    def _make_message(self) -> Mock:
+        message = Mock()
+        message.uuid = 'msg-uuid'
+        message.content = 'hello'
+        message.alias = None
+        message.user_uuid = 'user-uuid'
+        message.tenant_uuid = 'tenant-uuid'
+        message.wazo_uuid = 'wazo-uuid'
+        message.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        message.room = Mock(uuid='room-uuid')
+        message.meta = Mock(type_='sms', backend='twilio', status='delivered')
+        return message
+
+    async def test_publishes_event_per_user(self) -> None:
+        room = Mock()
+        room.uuid = 'room-uuid'
+        room.tenant_uuid = 'tenant-uuid'
+        room.users = [Mock(uuid='user-1'), Mock(uuid='user-2')]
+
+        await self.notifier.message_created(room, self._make_message())
+
+        assert self.bus.publish.call_count == 2
+
+    async def test_publishes_correct_event_type(self) -> None:
+        room = Mock()
+        room.uuid = 'room-uuid'
+        room.tenant_uuid = 'tenant-uuid'
+        room.users = [Mock(uuid='user-1')]
+
+        await self.notifier.message_created(room, self._make_message())
+
+        event = self.bus.publish.call_args[0][0]
+        assert event.name == 'chatd_user_room_message_created'
+
+    async def test_event_includes_delivery(self) -> None:
+        room = Mock()
+        room.uuid = 'room-uuid'
+        room.tenant_uuid = 'tenant-uuid'
+        room.users = [Mock(uuid='user-1')]
+
+        await self.notifier.message_created(room, self._make_message())
+
+        event = self.bus.publish.call_args[0][0]
+        delivery = event.content['delivery']
+        assert delivery['type'] == 'sms'
+        assert delivery['backend'] == 'twilio'
+        assert delivery['status'] == 'delivered'
+
+
+class TestAsyncNotifierDeliveryStatusUpdated(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.bus = Mock()
+        self.notifier = AsyncNotifier(self.bus)
+        self.room = Mock(
+            uuid='room-uuid', tenant_uuid='tenant-uuid', users=[Mock(uuid='user-1')]
+        )
+
+    def _make_meta_and_record(self) -> tuple[Mock, Mock]:
+        meta = Mock(message_uuid='msg-uuid', backend='twilio')
+        record = Mock(
+            status='sent', timestamp=datetime(2026, 3, 30, 14, tzinfo=timezone.utc)
+        )
+        return meta, record
+
+    async def test_publishes_delivery_status_event(self) -> None:
+        meta, record = self._make_meta_and_record()
+
+        await self.notifier.delivery_status_updated(meta, record, self.room)
+
+        self.bus.publish.assert_called_once()
+        event = self.bus.publish.call_args[0][0]
+        assert event.name == 'chatd_message_delivery_status'
+
+    async def test_delivered_status_publishes_message_created_to_other_users(
+        self,
+    ) -> None:
+        sender = Mock(uuid='sender-uuid', identity=None)
+        recipient = Mock(uuid='recipient-uuid', identity=None)
+        room = Mock(
+            uuid='room-uuid',
+            tenant_uuid='tenant-uuid',
+            users=[sender, recipient],
+        )
+        meta = Mock(
+            message_uuid='msg-uuid',
+            backend='twilio',
+            message=Mock(user_uuid='sender-uuid'),
+        )
+        record = Mock(
+            status='delivered',
+            timestamp=datetime(2026, 3, 30, 14, tzinfo=timezone.utc),
+        )
+
+        await self.notifier.delivery_status_updated(meta, record, room)
+
+        events = [call.args[0] for call in self.bus.publish.call_args_list]
+        status_events = [e for e in events if e.name == 'chatd_message_delivery_status']
+        message_events = [
+            e for e in events if e.name == 'chatd_user_room_message_created'
+        ]
+        assert len(status_events) == 1
+        assert len(message_events) == 1
+        assert message_events[0].user_uuid == 'recipient-uuid'
+
+    async def test_non_delivered_status_does_not_publish_message_created(self) -> None:
+        meta, record = self._make_meta_and_record()
+
+        await self.notifier.delivery_status_updated(meta, record, self.room)
+
+        events = [call.args[0] for call in self.bus.publish.call_args_list]
+        message_events = [
+            e for e in events if e.name == 'chatd_user_room_message_created'
+        ]
+        assert len(message_events) == 0
+
+    async def test_publish_error_does_not_propagate(self) -> None:
+        self.bus.publish.side_effect = RuntimeError('connection lost')
+        meta, record = self._make_meta_and_record()
+
+        await self.notifier.delivery_status_updated(meta, record, self.room)

--- a/wazo_chatd/plugins/connectors/tests/test_router.py
+++ b/wazo_chatd/plugins/connectors/tests/test_router.py
@@ -1,0 +1,243 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+import uuid
+from typing import ClassVar
+from unittest.mock import Mock
+
+import pytest
+
+from wazo_chatd.plugin_helpers.dependencies import MessageContext
+from wazo_chatd.plugins.connectors.exceptions import (
+    ConnectorParseError,
+    MessageIdentityRequiredError,
+)
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.router import ConnectorRouter
+from wazo_chatd.plugins.connectors.types import (
+    InboundMessage,
+    StatusUpdate,
+    TransportData,
+    WebhookData,
+)
+
+
+class _SmsConnector:
+    backend: ClassVar[str] = 'twilio'
+    supported_types: ClassVar[tuple[str, ...]] = ('sms', 'mms')
+
+    @classmethod
+    def normalize_identity(cls, raw_identity: str) -> str:
+        if raw_identity.startswith('+'):
+            return raw_identity
+        raise ValueError(f'Not a phone number: {raw_identity}')
+
+    @classmethod
+    def can_handle(cls, data: TransportData) -> bool:
+        return True
+
+    @classmethod
+    def on_event(cls, data: TransportData) -> InboundMessage | StatusUpdate | None:
+        match data:
+            case WebhookData(body=body) if body.get('Body'):
+                return InboundMessage(
+                    sender=body.get('From', ''),
+                    recipient=body.get('To', ''),
+                    body=body['Body'],
+                    backend=cls.backend,
+                    message_type='sms',
+                    external_id=body.get('MessageSid', ''),
+                )
+            case _:
+                return None
+
+
+class _EmailConnector:
+    backend: ClassVar[str] = 'mailgun'
+    supported_types: ClassVar[tuple[str, ...]] = ('email',)
+
+    @classmethod
+    def normalize_identity(cls, raw_identity: str) -> str:
+        if '@' in raw_identity:
+            return raw_identity.lower()
+        raise ValueError(f'Not an email: {raw_identity}')
+
+    @classmethod
+    def can_handle(cls, data: TransportData) -> bool:
+        match data:
+            case WebhookData(body=body):
+                return 'X-Mailgun-Signature' in body
+            case _:
+                return False
+
+    @classmethod
+    def on_event(cls, data: TransportData) -> InboundMessage | StatusUpdate | None:
+        return None
+
+
+def _make_room_user(
+    uuid: str = 'user-uuid',
+    identity: str | None = None,
+) -> Mock:
+    user = Mock()
+    user.uuid = uuid
+    user.identity = identity
+    return user
+
+
+def _make_room(users: list[Mock] | None = None) -> Mock:
+    room = Mock()
+    room.users = users or []
+    return room
+
+
+def _build_registry() -> ConnectorRegistry:
+    registry = ConnectorRegistry()
+    registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+    registry.register_backend(_EmailConnector)  # type: ignore[arg-type]
+    return registry
+
+
+def _build_router(
+    config: dict | None = None,
+    registry: ConnectorRegistry | None = None,
+    service: Mock | None = None,
+    auth_client: Mock | None = None,
+) -> ConnectorRouter:
+    with unittest.mock.patch('wazo_chatd.plugins.connectors.router.DeliveryLoop'):
+        return ConnectorRouter(
+            config=config or {},
+            registry=registry or ConnectorRegistry(),
+            service=service or Mock(),
+            auth_client=auth_client or Mock(),
+        )
+
+
+class TestConnectorRouterDispatchWebhook(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = ConnectorRegistry()
+        self.router = _build_router(registry=self.registry)
+        self.manager = self.router._delivery_loop
+
+    def test_dispatch_enqueues_inbound_message(self) -> None:
+        self.registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+        data = WebhookData(
+            body={'From': '+15559876', 'Body': 'hello', 'MessageSid': 'msg-123'}
+        )
+
+        self.router.dispatch_webhook(data, backend='twilio')
+
+        self.manager.enqueue_message.assert_called_once()
+        result = self.manager.enqueue_message.call_args[0][0]
+        assert isinstance(result, InboundMessage)
+        assert result.body == 'hello'
+
+    def test_dispatch_without_backend_hint(self) -> None:
+        self.registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+        data = WebhookData(
+            body={'From': '+15559876', 'Body': 'hi', 'MessageSid': 'msg-1'}
+        )
+
+        self.router.dispatch_webhook(data)
+
+        self.manager.enqueue_message.assert_called_once()
+
+    def test_dispatch_skips_connector_that_cannot_handle(self) -> None:
+        self.registry.register_backend(_EmailConnector)  # type: ignore[arg-type]
+        self.registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+        data = WebhookData(
+            body={'From': '+15559876', 'Body': 'hello', 'MessageSid': 'msg-1'}
+        )
+
+        self.router.dispatch_webhook(data)
+
+        self.manager.enqueue_message.assert_called_once()
+        result = self.manager.enqueue_message.call_args[0][0]
+        assert result.backend == 'twilio'
+
+    def test_dispatch_skips_none_events(self) -> None:
+        self.registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+        data = WebhookData(body={'no_body_or_status': True})
+
+        with pytest.raises(ConnectorParseError):
+            self.router.dispatch_webhook(data)
+
+        self.manager.enqueue_message.assert_not_called()
+
+    def test_dispatch_no_backends_raises(self) -> None:
+        with pytest.raises(ConnectorParseError):
+            self.router.dispatch_webhook(WebhookData(body={}))
+
+    def test_dispatch_falls_back_to_non_hint_connectors(self) -> None:
+        self.registry.register_backend(_SmsConnector)  # type: ignore[arg-type]
+        data = WebhookData(
+            body={'From': '+15559876', 'Body': 'hello', 'MessageSid': 'msg-1'}
+        )
+
+        self.router.dispatch_webhook(data, backend='vonage')
+
+        self.manager.enqueue_message.assert_called_once()
+        result = self.manager.enqueue_message.call_args[0][0]
+        assert result.backend == 'twilio'
+
+
+class TestConnectorRouterValidateOutbound(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = _build_registry()
+        self.service = Mock()
+        self.router = _build_router(registry=self.registry, service=self.service)
+
+    def test_internal_room_without_sender_identity_uuid_passes(self) -> None:
+        room = _make_room([_make_room_user('user-a'), _make_room_user('user-b')])
+        ctx = MessageContext(room, Mock(), sender_identity_uuid=None)
+
+        self.router.prepare_outbound(ctx)
+
+        self.service.validate_identity_reachability.assert_not_called()
+
+    def test_external_room_without_sender_identity_uuid_raises_409(self) -> None:
+        room = _make_room(
+            [
+                _make_room_user('user-a'),
+                _make_room_user('ext-uuid', identity='+15559876'),
+            ]
+        )
+        ctx = MessageContext(room, Mock(), sender_identity_uuid=None)
+
+        with pytest.raises(MessageIdentityRequiredError):
+            self.router.prepare_outbound(ctx)
+
+    def test_sender_identity_uuid_validates_and_prepares_delivery(self) -> None:
+        room = _make_room([_make_room_user('user-a'), _make_room_user('user-b')])
+        identity_uuid = uuid.uuid4()
+        identity = Mock()
+        self.service.validate_identity_reachability.return_value = identity
+        message = Mock(user_uuid='user-a')
+        ctx = MessageContext(room, message, sender_identity_uuid=identity_uuid)
+
+        self.router.prepare_outbound(ctx)
+
+        self.service.validate_identity_reachability.assert_called_once_with(
+            room, 'user-a', identity_uuid
+        )
+        self.service.prepare_outbound_delivery.assert_called_once_with(
+            message, identity
+        )
+        assert ctx.resolved_sender_identity is identity
+
+
+class TestConnectorRouterValidateRoomCreation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = _build_registry()
+        self.service = Mock()
+        self.router = _build_router(registry=self.registry, service=self.service)
+
+    def test_delegates_to_service(self) -> None:
+        room = _make_room([_make_room_user('user-a'), _make_room_user('user-b')])
+
+        self.router.validate_room_creation(room)
+
+        self.service.validate_room_reachability.assert_called_once_with(room)


### PR DESCRIPTION
## Summary

### Outbound flow
```
Flask API → Router.prepare_outbound → pg_notify → DeliveryLoop → Executor.route_outbound → connector.send()
```
- Router validates room reachability and identity, prepares MessageMeta in before_message_creation hook
- pg_notify bridges the sync Flask path to the async delivery loop (fires on commit)
- Executor resolves recipient identity, sends via connector, tracks delivery records with retry/backoff
- Unexpected SDK errors treated as retriable failures (not just ConnectorSendError)

### Inbound flow
```
Webhook → Router.dispatch_webhook → can_handle() → on_event() → DeliveryLoop → Executor.route_inbound
```
- Two-phase dispatch: `can_handle` pre-filter, then `on_event` parsing (both classmethods, no instance needed)
- Echo dedup via message signature (sha256 of sender_identity + normalized body[:160])
- Inbound retry with backoff (2s, 5s, 10s) for transient persistence failures

### Notifications
- Outbound pending: sender only gets `message_created` event
- Delivered: all other internal participants get `message_created`
- Status updates: `delivery_status` events to all room participants
- Identity CRUD: `identity_created/updated/deleted` events

### Recovery
- On startup, recovers pending/sending/retrying deliveries from DB
- Retrying messages re-enqueued with delay based on retry count

## Files
- `executor.py` — outbound send, inbound routing, status updates, echo dedup, recovery
- `loop.py` — asyncio event loop, LISTEN/NOTIFY listener, bounded concurrency, crash recovery
- `notifier.py` — async + sync bus event publishing
- `router.py` — sync entry point, validation, webhook dispatch
- `bus_consume.py` — placeholder for future bus event handling

## Test plan
- [ ] `python -m pytest wazo_chatd/plugins/connectors/tests/test_executor.py -v`
- [ ] `python -m pytest wazo_chatd/plugins/connectors/tests/test_loop.py -v`
- [ ] `python -m pytest wazo_chatd/plugins/connectors/tests/test_notifier.py -v`
- [ ] `python -m pytest wazo_chatd/plugins/connectors/tests/test_router.py -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a new background delivery loop wired to Postgres `LISTEN/NOTIFY` and changes how message delivery/persistence and status events are executed and retried. Failures or race conditions here can drop, duplicate, or misreport message deliveries.
> 
> **Overview**
> Adds a new async connector delivery pipeline: a background `DeliveryLoop` thread `LISTEN`s for Postgres `connector_delivery` notifications, recovers pending/retrying messages on startup, and runs inbound/status tasks with bounded concurrency and crash-restart backoff.
> 
> Introduces `DeliveryExecutor` to handle outbound sends (connector lookup, idempotency metadata, delivery-record state machine, retry/dead-letter logic, and sync/async connector support), inbound webhook persistence (recipient/sender identity resolution, room creation, idempotency + echo dedup via `message_signature`, and DB-write retries), and provider status updates (status mapping → delivery records).
> 
> Adds async/sync bus event publishing via `AsyncNotifier`/`UserIdentityNotifier` including new delivery-status events, and wires the connector subsystem entrypoint through `ConnectorRouter` (webhook dispatching, outbound validation/prep, lifecycle/status reporting). A placeholder `ConnectorBusEventHandler` and comprehensive unit tests for the new loop/executor/router/notifier are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4bd337b61ef0fdfd92251ba05ccd9d85b231d81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->