### PR TITLE
[ITEM-101] Extend rooms plugin for connector support

### DIFF
--- a/integration_tests/suite/test_user_room.py
+++ b/integration_tests/suite/test_user_room.py
@@ -49,10 +49,16 @@ class TestUserRoom(APIIntegrationTest):
             has_entries(
                 items=contains_inanyorder(
                     has_entries(
-                        uuid=room_1['uuid'], users=contains_inanyorder(*room_1['users'])
+                        uuid=room_1['uuid'],
+                        users=contains_inanyorder(
+                            *[has_entries(**u) for u in room_1['users']]
+                        ),
                     ),
                     has_entries(
-                        uuid=room_2['uuid'], users=contains_inanyorder(*room_2['users'])
+                        uuid=room_2['uuid'],
+                        users=contains_inanyorder(
+                            *[has_entries(**u) for u in room_2['users']]
+                        ),
                     ),
                 ),
                 total=equal_to(2),
@@ -138,7 +144,9 @@ class TestUserRoom(APIIntegrationTest):
             has_entries(
                 uuid=uuid_(),
                 name=room_args['name'],
-                users=contains_inanyorder(*room_args['users']),
+                users=contains_inanyorder(
+                    *[has_entries(**u) for u in room_args['users']]
+                ),
             ),
         )
 
@@ -148,14 +156,14 @@ class TestUserRoom(APIIntegrationTest):
             contains_inanyorder(
                 has_entries(
                     message=has_entries(
-                        data=has_entries(room_args),
+                        data=has_entries(name=room_args['name']),
                         required_acl=f'events.chatd.users.{TOKEN_USER_UUID}.rooms.created',
                     ),
                     headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
                 ),
                 has_entries(
                     message=has_entries(
-                        data=has_entries(room_args),
+                        data=has_entries(name=room_args['name']),
                         required_acl=f'events.chatd.users.{UUID}.rooms.created',
                     ),
                     headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),
@@ -187,7 +195,9 @@ class TestUserRoom(APIIntegrationTest):
             has_entries(
                 uuid=uuid_(),
                 name=room_args['name'],
-                users=contains_inanyorder(*room_args['users']),
+                users=contains_inanyorder(
+                    *[has_entries(**u) for u in room_args['users']]
+                ),
             ),
         )
 
@@ -195,7 +205,7 @@ class TestUserRoom(APIIntegrationTest):
         expected_entries = [
             has_entries(
                 message=has_entries(
-                    data=has_entries(room_args),
+                    data=has_entries(name=room_args['name']),
                     required_acl=f'events.chatd.users.{uuid}.rooms.created',
                 ),
                 headers=has_entries(tenant_uuid=str(TOKEN_TENANT_UUID)),

--- a/wazo_chatd/plugins/connectors/services.py
+++ b/wazo_chatd/plugins/connectors/services.py
@@ -1,0 +1,206 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from wazo_chatd.exceptions import UnknownRoomException
+from wazo_chatd.plugins.connectors.exceptions import (
+    InvalidIdentityError,
+    NoCommonConnectorError,
+    UnreachableParticipantError,
+)
+from wazo_chatd.plugins.connectors.notifier import UserIdentityNotifier
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+
+if TYPE_CHECKING:
+    from wazo_chatd.database.models import Room, RoomMessage, RoomUser, UserIdentity
+    from wazo_chatd.database.queries import DAO
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectorService:
+    def __init__(
+        self,
+        dao: DAO,
+        registry: ConnectorRegistry,
+        notifier: UserIdentityNotifier,
+    ) -> None:
+        self._dao = dao
+        self._registry = registry
+        self._notifier = notifier
+
+    def list_identities(
+        self, tenant_uuids: list[str], user_uuid: str
+    ) -> list[UserIdentity]:
+        return self._dao.user_identity.list_by_user(
+            user_uuid, tenant_uuids=tenant_uuids
+        )
+
+    def get_identity(
+        self,
+        tenant_uuids: list[str],
+        identity_uuid: str,
+        user_uuid: str | None = None,
+    ) -> UserIdentity:
+        return self._dao.user_identity.get(
+            tenant_uuids, identity_uuid, user_uuid=user_uuid
+        )
+
+    def create_identity(self, identity: UserIdentity) -> UserIdentity:
+        created = self._dao.user_identity.create(identity)
+        self._notifier.created(created)
+        return created
+
+    def update_identity(self, identity: UserIdentity) -> UserIdentity:
+        self._dao.user_identity.update(identity)
+        self._notifier.updated(identity)
+        return identity
+
+    def delete_identity(self, identity: UserIdentity) -> None:
+        self._dao.user_identity.delete(identity)
+        self._notifier.deleted(identity)
+
+    def prepare_outbound_delivery(
+        self,
+        message: RoomMessage,
+        sender_identity: UserIdentity,
+    ) -> None:
+        self._dao.room.prepare_pending_delivery(
+            message,
+            sender_identity.uuid,
+            backend=sender_identity.backend,  # type: ignore[arg-type]
+            type_=sender_identity.type_,  # type: ignore[arg-type]
+        )
+
+    def list_room_identities(
+        self,
+        tenant_uuids: list[str],
+        room_uuid: str,
+        user_uuid: str,
+    ) -> list[UserIdentity]:
+        room = self._dao.room.get(tenant_uuids, room_uuid)
+
+        if user_uuid not in {str(u.uuid) for u in room.users}:
+            raise UnknownRoomException(room_uuid)
+
+        others = [u for u in room.users if str(u.uuid) != user_uuid]
+        if not others:
+            return []
+
+        reachable_types: set[str] | None = None
+        for participant in others:
+            participant_types = self._resolve_participant_types(participant)
+            if reachable_types is None:
+                reachable_types = participant_types
+            else:
+                reachable_types &= participant_types
+
+        if not reachable_types:
+            return []
+
+        return self._dao.user_identity.list_by_user(user_uuid, types=reachable_types)
+
+    def validate_room_reachability(self, room: Room) -> None:
+        participants = room.users
+        if len(participants) < 2:
+            return
+
+        external = [u for u in participants if u.identity]
+        if not external:
+            return
+
+        needs_db_lookup: list[RoomUser] = []
+
+        external_identities = [str(u.identity) for u in external]
+        bound_identities = (
+            self._dao.user_identity.list_bound_identities(external_identities)
+            if external_identities
+            else set()
+        )
+
+        types_by_participant: dict[str, set[str]] = {}
+
+        for user in external:
+            identity = str(user.identity)
+            if identity in bound_identities:
+                needs_db_lookup.append(user)
+            else:
+                reachable = self._registry.resolve_reachable_types(identity)
+                if not reachable:
+                    raise UnreachableParticipantError(identity)
+                types_by_participant[str(user.uuid)] = reachable
+
+        internal = [u for u in participants if not u.identity]
+        needs_db_lookup.extend(internal)
+
+        if needs_db_lookup:
+            db_types = self._dao.user_identity.list_types_by_users(
+                [str(u.uuid) for u in needs_db_lookup]
+            )
+            for user in needs_db_lookup:
+                user_types = db_types.get(str(user.uuid), set())
+                if not user_types:
+                    raise UnreachableParticipantError(str(user.identity or user.uuid))
+                types_by_participant[str(user.uuid)] = user_types
+
+        common_types: set[str] | None = None
+        for types in types_by_participant.values():
+            if common_types is None:
+                common_types = types
+            else:
+                common_types &= types
+
+        if not common_types:
+            raise NoCommonConnectorError()
+
+    def validate_identity_reachability(
+        self,
+        room: Room,
+        sender_uuid: str,
+        sender_identity_uuid: UUID,
+    ) -> UserIdentity:
+        record = self._dao.user_identity.find(str(sender_identity_uuid))
+        if not record:
+            raise InvalidIdentityError(str(sender_identity_uuid))
+
+        sender_backend = str(record.backend)
+        sender_type = str(record.type_)
+        others = [u for u in room.users if str(u.uuid) != sender_uuid]
+
+        internal = [u for u in others if not u.identity]
+        external = [u for u in others if u.identity]
+
+        if internal:
+            internal_types = self._dao.user_identity.list_types_by_users(
+                [str(u.uuid) for u in internal]
+            )
+            for user in internal:
+                user_types = internal_types.get(str(user.uuid), set())
+                if sender_type not in user_types:
+                    raise UnreachableParticipantError(str(user.uuid), sender_backend)
+
+        for user in external:
+            reachable_types = self._registry.resolve_reachable_types(str(user.identity))
+            if sender_type not in reachable_types:
+                raise UnreachableParticipantError(str(user.identity), sender_backend)
+
+        return record
+
+    def _resolve_participant_types(self, participant: RoomUser) -> set[str]:
+        identity: str | None = participant.identity  # type: ignore[assignment]
+
+        if identity is not None:
+            if self._dao.user_identity.is_identity_bound(identity):
+                user_id = str(participant.uuid)
+                types_map = self._dao.user_identity.list_types_by_users([user_id])
+                return types_map.get(user_id, set())
+            return self._registry.resolve_reachable_types(identity)
+
+        user_id = str(participant.uuid)
+        types_map = self._dao.user_identity.list_types_by_users([user_id])
+        return types_map.get(user_id, set())

--- a/wazo_chatd/plugins/rooms/http.py
+++ b/wazo_chatd/plugins/rooms/http.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from flask import request
@@ -114,12 +114,17 @@ class UserRoomMessageListResource(AuthResource):
     def post(self, room_uuid):
         room = self._service.get([token.tenant_uuid], room_uuid)
         message_args = MessageSchema().load(request.get_json(force=True))
+        sender_identity_uuid = message_args.pop('sender_identity_uuid', None)
         message_args['user_uuid'] = token.user_uuid
         message_args['tenant_uuid'] = token.tenant_uuid
         message = RoomMessage(**message_args)
 
-        message = self._service.create_message(room, message)
-        return MessageSchema().dump(message), 201
+        message = self._service.create_message(
+            room, message, sender_identity_uuid=sender_identity_uuid
+        )
+        has_delivery = sender_identity_uuid and self._service.has_delivery_pipeline()
+        status_code = 202 if has_delivery else 201
+        return MessageSchema().dump(message), status_code
 
     @required_acl('chatd.users.me.rooms.{room_uuid}.messages.read')
     def get(self, room_uuid):
@@ -128,9 +133,14 @@ class UserRoomMessageListResource(AuthResource):
         if token.user_uuid not in {str(user.uuid) for user in room.users}:
             raise UnknownRoomException(room_uuid)
 
-        messages = self._service.list_messages(room, **filter_parameters)
-        filtered = self._service.count_messages(room, **filter_parameters)
-        total = self._service.count_messages(room)
+        viewer_uuid = token.user_uuid
+        messages = self._service.list_messages(
+            room, viewer_uuid=viewer_uuid, **filter_parameters
+        )
+        filtered = self._service.count_messages(
+            room, viewer_uuid=viewer_uuid, **filter_parameters
+        )
+        total = self._service.count_messages(room, viewer_uuid=viewer_uuid)
         return {
             'items': MessageSchema().dump(messages, many=True),
             'filtered': filtered,

--- a/wazo_chatd/plugins/rooms/notifier.py
+++ b/wazo_chatd/plugins/rooms/notifier.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_bus.resources.chatd.events import (
@@ -21,7 +21,14 @@ class RoomNotifier:
 
     def message_created(self, room, message):
         message_json = MessageSchema().dump(message)
-        for user in room.users:
+        recipients = [u for u in room.users if not u.identity]
+
+        if message.meta and message.meta.status != 'delivered':
+            recipients = [
+                u for u in recipients if str(u.uuid) == str(message.user_uuid)
+            ]
+
+        for user in recipients:
             event = UserRoomMessageCreatedEvent(
                 message_json, room.uuid, room.tenant_uuid, user.uuid
             )

--- a/wazo_chatd/plugins/rooms/plugin.py
+++ b/wazo_chatd/plugins/rooms/plugin.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .http import (
@@ -16,9 +16,10 @@ class Plugin:
         config = dependencies['config']
         dao = dependencies['dao']
         bus_publisher = dependencies['bus_publisher']
+        hooks = dependencies['hooks']
 
         notifier = RoomNotifier(bus_publisher)
-        service = RoomService(config['uuid'], dao, notifier)
+        service = RoomService(config['uuid'], dao, notifier, hooks)
 
         api.add_resource(
             UserRoomListResource, '/users/me/rooms', resource_class_args=[service]

--- a/wazo_chatd/plugins/rooms/schemas.py
+++ b/wazo_chatd/plugins/rooms/schemas.py
@@ -1,9 +1,9 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from marshmallow import pre_load, validates_schema
+from marshmallow import post_dump, pre_load, validates_schema
 from xivo.mallow import fields, validate
 from xivo.mallow_helpers import ListSchema as _ListSchema
 from xivo.mallow_helpers import Schema, ValidationError
@@ -13,6 +13,7 @@ class RoomUserSchema(Schema):
     uuid = fields.UUID()
     tenant_uuid = fields.UUID()
     wazo_uuid = fields.UUID()
+    identity = fields.String(allow_none=True)
 
 
 class RoomSchema(Schema):
@@ -24,16 +25,30 @@ class RoomSchema(Schema):
     users = fields.Nested('RoomUserSchema', many=True, load_default=list)
 
 
+class MessageDeliverySchema(Schema):
+    type = fields.String(dump_default='internal', attribute='type_')
+    backend = fields.String(dump_default=None, allow_none=True)
+    status = fields.String(dump_default='delivered')
+
+
 class MessageSchema(Schema):
     uuid = fields.UUID(dump_only=True)
     content = fields.String(required=True)
     alias = fields.String(validate=validate.Length(max=256), allow_none=True)
+    delivery = fields.Nested(MessageDeliverySchema, dump_only=True, attribute='meta')
     user_uuid = fields.UUID(dump_only=True)
     tenant_uuid = fields.UUID(dump_only=True)
     wazo_uuid = fields.UUID(dump_only=True)
     created_at = fields.DateTime(dump_only=True)
+    sender_identity_uuid = fields.UUID(load_only=True, allow_none=True)
 
     room = fields.Nested('RoomSchema', dump_only=True, only=['uuid'])
+
+    @post_dump
+    def _default_delivery(self, data: dict, **kwargs: object) -> dict:
+        if data.get('delivery') is None:
+            data['delivery'] = MessageDeliverySchema().dump({})
+        return data
 
 
 class ListRequestSchema(_ListSchema):

--- a/wazo_chatd/plugins/rooms/services.py
+++ b/wazo_chatd/plugins/rooms/services.py
@@ -1,15 +1,36 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from wazo_chatd.plugin_helpers.dependencies import MessageContext
+from wazo_chatd.plugin_helpers.hooks import Hooks
+
+if TYPE_CHECKING:
+    from wazo_chatd.database.models import Room, RoomMessage
+    from wazo_chatd.database.queries import DAO
+    from wazo_chatd.plugins.rooms.notifier import RoomNotifier
 
 
 class RoomService:
-    def __init__(self, wazo_uuid, dao, notifier):
+    def __init__(
+        self,
+        wazo_uuid: str,
+        dao: DAO,
+        notifier: RoomNotifier,
+        hooks: Hooks,
+    ) -> None:
         self._dao = dao
         self._notifier = notifier
         self._wazo_uuid = wazo_uuid
+        self._hooks = hooks
 
     def create(self, room):
         self._set_default_room_values(room)
+        self._hooks.dispatch('before_room_creation', room, allow_raise=True)
         self._dao.room.create(room)
         self._notifier.created(room)
         return room
@@ -21,6 +42,9 @@ class RoomService:
             if user.wazo_uuid is None:
                 user.wazo_uuid = self._wazo_uuid
 
+    def has_delivery_pipeline(self) -> bool:
+        return self._hooks.has_subscribers('before_message_creation')
+
     def list_(self, tenant_uuids, **filter_parameters):
         return self._dao.room.list_(tenant_uuids, **filter_parameters)
 
@@ -30,8 +54,17 @@ class RoomService:
     def get(self, tenant_uuids, room_uuid):
         return self._dao.room.get(tenant_uuids, room_uuid)
 
-    def create_message(self, room, message):
+    def create_message(
+        self,
+        room: Room,
+        message: RoomMessage,
+        sender_identity_uuid: UUID | None = None,
+    ) -> RoomMessage:
         self._set_default_message_values(message)
+        context = MessageContext(
+            room, message, sender_identity_uuid=sender_identity_uuid
+        )
+        self._hooks.dispatch('before_message_creation', context, allow_raise=True)
         self._dao.room.add_message(room, message)
         self._notifier.message_created(room, message)
         return message
@@ -39,11 +72,15 @@ class RoomService:
     def _set_default_message_values(self, message):
         message.wazo_uuid = self._wazo_uuid
 
-    def list_messages(self, room, **filter_parameters):
-        return self._dao.room.list_messages(room, **filter_parameters)
+    def list_messages(self, room, viewer_uuid: str | None = None, **filter_parameters):
+        return self._dao.room.list_messages(
+            room, viewer_uuid=viewer_uuid, **filter_parameters
+        )
 
-    def count_messages(self, room, **filter_parameters):
-        return self._dao.room.count_messages(room, **filter_parameters)
+    def count_messages(self, room, viewer_uuid: str | None = None, **filter_parameters):
+        return self._dao.room.count_messages(
+            room, viewer_uuid=viewer_uuid, **filter_parameters
+        )
 
     def list_user_messages(self, tenant_uuid, user_uuid, **filter_parameters):
         return self._dao.room.list_user_messages(

--- a/wazo_chatd/plugins/rooms/tests/test_notifier.py
+++ b/wazo_chatd/plugins/rooms/tests/test_notifier.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from wazo_chatd.plugins.rooms.notifier import RoomNotifier
+
+
+class TestRoomNotifierMessageCreated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bus = Mock()
+        self.notifier = RoomNotifier(self.bus)
+
+    def test_internal_message_notifies_all_users(self) -> None:
+        room = Mock()
+        room.users = [
+            Mock(uuid='user-a', identity=None),
+            Mock(uuid='user-b', identity=None),
+        ]
+        message = Mock(meta=None, user_uuid='user-a')
+
+        self.notifier.message_created(room, message)
+
+        assert self.bus.publish.call_count == 2
+
+    def test_outbound_pending_notifies_sender_only(self) -> None:
+        room = Mock()
+        room.users = [
+            Mock(uuid='user-a', identity=None),
+            Mock(uuid='user-b', identity=None),
+        ]
+        message = Mock(user_uuid='user-a')
+        message.meta.status = 'pending'
+
+        self.notifier.message_created(room, message)
+
+        assert self.bus.publish.call_count == 1
+        event = self.bus.publish.call_args[0][0]
+        assert event.user_uuid == 'user-a'
+
+    def test_inbound_delivered_notifies_all_users(self) -> None:
+        room = Mock()
+        room.users = [
+            Mock(uuid='user-a', identity=None),
+            Mock(uuid='user-b', identity=None),
+        ]
+        message = Mock(user_uuid='user-a')
+        message.meta.status = 'delivered'
+
+        self.notifier.message_created(room, message)
+
+        assert self.bus.publish.call_count == 2
+
+    def test_external_participants_not_notified(self) -> None:
+        room = Mock()
+        room.users = [
+            Mock(uuid='user-a', identity=None),
+            Mock(uuid='ext-user', identity='+15559876'),
+        ]
+        message = Mock(meta=None, user_uuid='user-a')
+
+        self.notifier.message_created(room, message)
+
+        assert self.bus.publish.call_count == 1
+        event = self.bus.publish.call_args[0][0]
+        assert event.user_uuid == 'user-a'

--- a/wazo_chatd/plugins/rooms/tests/test_schemas.py
+++ b/wazo_chatd/plugins/rooms/tests/test_schemas.py
@@ -1,14 +1,19 @@
-# Copyright 2019-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 import uuid
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from hamcrest import assert_that, calling, has_entries, has_length, not_, raises
 from xivo.mallow_helpers import ValidationError
 
-from ..schemas import ListRequestSchema, MessageListRequestSchema, RoomListRequestSchema
+from ..schemas import (
+    ListRequestSchema,
+    MessageListRequestSchema,
+    MessageSchema,
+    RoomListRequestSchema,
+)
 
 
 class TestListRequestSchema(unittest.TestCase):
@@ -35,6 +40,52 @@ class TestMessageListRequestSchema(unittest.TestCase):
             calling(self.schema().load).with_args({'search': 'ok'}),
             not_(raises(ValidationError, pattern='search or distinct')),
         )
+
+
+class TestMessageSchemaDelivery(unittest.TestCase):
+    def test_internal_message_has_delivery_with_delivered_status(self) -> None:
+        message = Mock(
+            meta=None,
+            spec=[
+                'uuid',
+                'content',
+                'alias',
+                'user_uuid',
+                'tenant_uuid',
+                'wazo_uuid',
+                'created_at',
+                'room',
+                'meta',
+            ],
+        )
+
+        result = MessageSchema().dump(message)
+
+        assert result['delivery'] == {
+            'type': 'internal',
+            'backend': None,
+            'status': 'delivered',
+        }
+
+    def test_connector_message_has_delivery_from_meta(self) -> None:
+        meta = Mock(type_='sms', backend='twilio', status='sent')
+        message = Mock(meta=meta)
+
+        result = MessageSchema().dump(message)
+
+        assert result['delivery'] == {
+            'type': 'sms',
+            'backend': 'twilio',
+            'status': 'sent',
+        }
+
+    def test_connector_message_with_null_status(self) -> None:
+        meta = Mock(type_='sms', backend='twilio', status=None)
+        message = Mock(meta=meta)
+
+        result = MessageSchema().dump(message)
+
+        assert result['delivery']['status'] is None
 
 
 class TestRoomListRequestSchema(unittest.TestCase):

--- a/wazo_chatd/plugins/rooms/tests/test_services.py
+++ b/wazo_chatd/plugins/rooms/tests/test_services.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+import uuid
+from unittest.mock import Mock
+
+import pytest
+
+from wazo_chatd.plugin_helpers.dependencies import MessageContext
+from wazo_chatd.plugin_helpers.hooks import Hooks
+from wazo_chatd.plugins.rooms.services import RoomService
+
+WAZO_UUID = 'test-wazo-uuid'
+
+
+class TestRoomServiceCreate(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dao = Mock()
+        self.notifier = Mock()
+        self.hooks = Hooks()
+        self.service = RoomService(
+            WAZO_UUID,
+            self.dao,
+            self.notifier,
+            self.hooks,
+        )
+        self.room = Mock(
+            tenant_uuid='tenant-uuid',
+            users=[Mock(tenant_uuid=None, wazo_uuid=None)],
+        )
+
+    def test_create_dispatches_before_room_creation_before_persist(self) -> None:
+        call_order: list[str] = []
+        self.hooks.register(
+            'before_room_creation', lambda _: call_order.append('creating')
+        )
+        self.dao.room.create.side_effect = lambda *a: call_order.append('persist')
+
+        self.service.create(self.room)
+
+        assert call_order == ['creating', 'persist']
+
+    def test_create_before_room_creation_hook_rejects(self) -> None:
+        self.hooks.register(
+            'before_room_creation', Mock(side_effect=ValueError('rejected'))
+        )
+
+        with pytest.raises(ValueError, match='rejected'):
+            self.service.create(self.room)
+
+        self.dao.room.create.assert_not_called()
+        self.notifier.created.assert_not_called()
+
+
+class TestRoomServiceCreateMessage(unittest.TestCase):
+    def setUp(self) -> None:
+        self.dao = Mock()
+        self.notifier = Mock()
+        self.hooks = Hooks()
+        self.service = RoomService(
+            WAZO_UUID,
+            self.dao,
+            self.notifier,
+            self.hooks,
+        )
+        self.room = Mock()
+        self.message = Mock(wazo_uuid=None)
+        self.sender_identity_uuid = uuid.uuid4()
+
+    def test_create_message_persists_and_notifies(self) -> None:
+        result = self.service.create_message(self.room, self.message)
+
+        self.dao.room.add_message.assert_called_once_with(self.room, self.message)
+        self.notifier.message_created.assert_called_once_with(self.room, self.message)
+        assert result is self.message
+        assert self.message.wazo_uuid == WAZO_UUID
+
+    def test_create_message_dispatches_creating_hook_before_persist(self) -> None:
+        call_order: list[str] = []
+        self.hooks.register(
+            'before_message_creation', lambda _: call_order.append('creating')
+        )
+        self.dao.room.add_message.side_effect = lambda *a: call_order.append('persist')
+
+        self.service.create_message(self.room, self.message)
+
+        assert call_order == ['creating', 'persist']
+
+    def test_create_message_creating_hook_rejects(self) -> None:
+        self.hooks.register(
+            'before_message_creation', Mock(side_effect=ValueError('rejected'))
+        )
+
+        with pytest.raises(ValueError, match='rejected'):
+            self.service.create_message(self.room, self.message)
+
+        self.dao.room.add_message.assert_not_called()
+        self.notifier.message_created.assert_not_called()
+
+    def test_create_message_without_sender_identity_uuid(self) -> None:
+        callback = Mock()
+        self.hooks.register('before_message_creation', callback)
+
+        self.service.create_message(self.room, self.message)
+
+        ctx = callback.call_args[0][0]
+        assert isinstance(ctx, MessageContext)
+        assert ctx.sender_identity_uuid is None


### PR DESCRIPTION
## Summary
- Add `MessageDeliverySchema` nested under `MessageSchema` with `type`, `backend`, `status`
- Internal messages get `{"type": "internal", "backend": null, "status": "delivered"}`
- Add `sender_identity_uuid` (load-only) to message creation endpoint
- Wire `Hooks` into `RoomService` for `before_message_creation` interceptors
- Update `RoomNotifier`: pending outbound → sender only, delivered → all internal
- Add message visibility filter: `_filter_visible_messages` helper
- Return 202 when outbound delivery pipeline is active

## Test plan
- [ ] `python -m pytest wazo_chatd/plugins/rooms/tests/ -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message creation semantics (new `sender_identity_uuid`, conditional `202 Accepted`) and alters message/event visibility based on delivery status, which can affect clients and notifications. Also introduces new connector reachability logic that depends on DAO/registry behavior.
> 
> **Overview**
> Adds connector support to rooms by introducing `sender_identity_uuid` on message creation, emitting `delivery` metadata on messages, and returning **`202 Accepted`** when an outbound delivery pipeline is active.
> 
> Wires `Hooks` into `RoomService` (`before_room_creation`, `before_message_creation`) and updates room message reads to pass `viewer_uuid` so pending/outbound messages are only visible to the sender.
> 
> Updates `RoomNotifier` to notify only internal participants and to notify *sender-only* for non-`delivered` messages, and adds a new `ConnectorService` to manage user identities and validate room/identity reachability across connector types. Tests and integration assertions are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0df19b150ca1d3916142875b8d0cb30edaf61b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->