### PR TITLE
[ITEM-101] Add connector integration tests

### DIFF
--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,4 +1,4 @@
-test-setup: egg-info microsoft-mock chatd chatd-test db
+test-setup: egg-info microsoft-mock chatd chatd-test chatd-connectors-test connector-mock-test db
 
 test:
 	pytest -x
@@ -15,7 +15,13 @@ chatd:
 chatd-test: egg-info
 	docker build --no-cache -t wazo-chatd-test -f Dockerfile-chatd ..
 
+chatd-connectors-test: chatd-test
+	docker build --no-cache -t wazo-chatd-connectors-test -f docker/Dockerfile-chatd-connectors .
+
+connector-mock-test:
+	docker build --no-cache -t connector-mock-test -f docker/Dockerfile-connector-mock .
+
 db:
 	docker build -f ../contribs/docker/Dockerfile-db -t wazoplatform/wazo-chatd-db ..
 
-.PHONY: test-setup test egg-info chatd chatd-test
+.PHONY: test-setup test egg-info chatd chatd-test chatd-connectors-test connector-mock-test db

--- a/integration_tests/assets/connectors/servers/test-connector-server.py
+++ b/integration_tests/assets/connectors/servers/test-connector-server.py
@@ -1,0 +1,59 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import sys
+
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+_config: dict[str, str] = {
+    'send_behavior': 'succeed',
+    'external_id': '',
+    'error_message': 'Test connector failure',
+}
+
+_sent_messages: list[dict[str, str]] = []
+
+
+@app.route('/config', methods=['GET'])
+def get_config():
+    return jsonify(_config)
+
+
+@app.route('/config', methods=['PUT'])
+def set_config():
+    _config.update(request.get_json(force=True))
+    return jsonify(_config)
+
+
+@app.route('/sent', methods=['GET'])
+def list_sent():
+    return jsonify(_sent_messages)
+
+
+@app.route('/sent', methods=['POST'])
+def report_sent():
+    _sent_messages.append(request.get_json(force=True))
+    return '', 204
+
+
+@app.route('/reset', methods=['POST'])
+def reset():
+    _config.clear()
+    _config.update(
+        {
+            'send_behavior': 'succeed',
+            'external_id': '',
+            'error_message': 'Test connector failure',
+        }
+    )
+    _sent_messages.clear()
+    return '', 204
+
+
+if __name__ == '__main__':
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+    app.run(host='0.0.0.0', port=port)

--- a/integration_tests/assets/connectors/test-connector/pyproject.toml
+++ b/integration_tests/assets/connectors/test-connector/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "wazo-chatd-connector-mock"
+version = "0.1.0"
+description = "Test connector backend for wazo-chatd integration tests"
+requires-python = ">=3.11"
+dependencies = ["requests"]
+
+[project.entry-points."wazo_chatd.connectors"]
+test = "test_connector.connector:TestConnector"
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/integration_tests/assets/connectors/test-connector/test_connector/connector.py
+++ b/integration_tests/assets/connectors/test-connector/test_connector/connector.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Callable, Mapping
+from typing import Any, ClassVar
+
+import requests
+
+from wazo_chatd.database.delivery import DeliveryStatus
+from wazo_chatd.plugins.connectors.exceptions import ConnectorSendError
+from wazo_chatd.plugins.connectors.types import (
+    InboundMessage,
+    OutboundMessage,
+    StatusUpdate,
+    TransportData,
+    WebhookData,
+)
+
+logger = logging.getLogger(__name__)
+
+MOCK_URL = os.environ.get('TEST_CONNECTOR_MOCK_URL', 'http://connector-mock:8080')
+
+
+class TestConnector:
+    backend: ClassVar[str] = 'test'
+    supported_types: ClassVar[tuple[str, ...]] = ('test', 'test_alt')
+    status_map: ClassVar[dict[str, DeliveryStatus]] = {
+        'sent': DeliveryStatus.SENT,
+        'delivered': DeliveryStatus.DELIVERED,
+        'failed': DeliveryStatus.FAILED,
+    }
+
+    def __init__(
+        self,
+        provider_config: Mapping[str, Any],
+        connector_config: Mapping[str, Any],
+    ) -> None:
+        self._mock_url: str = MOCK_URL
+        mock_url = provider_config.get('mock_url')
+        if mock_url:
+            self._mock_url = str(mock_url)
+
+    def send(self, message: OutboundMessage) -> str:
+        config = self._get_config()
+        behavior = config.get('send_behavior', 'succeed')
+
+        self._report_sent(message)
+
+        if behavior == 'fail':
+            raise ConnectorSendError(
+                config.get('error_message', 'Test connector failure')
+            )
+
+        return config.get('external_id', f'test-{message.message_uuid}')
+
+    @classmethod
+    def can_handle(cls, data: TransportData) -> bool:
+        match data:
+            case WebhookData(headers=headers):
+                return 'X-Test-Connector' in headers
+            case _:
+                return True
+
+    @classmethod
+    def on_event(cls, data: TransportData) -> InboundMessage | StatusUpdate | None:
+        match data:
+            case WebhookData(body=body):
+                return cls._parse_webhook(body)
+            case _:
+                return None
+
+    @classmethod
+    def _parse_webhook(
+        cls, body: Mapping[str, Any]
+    ) -> InboundMessage | StatusUpdate | None:
+        content = body.get('body')
+        if content:
+            return InboundMessage(
+                sender=body.get('from', ''),
+                recipient=body.get('to', ''),
+                body=str(content),
+                backend=cls.backend,
+                message_type=body.get('type', 'test'),
+                external_id=body.get('message_id', ''),
+                metadata=dict(body),
+            )
+
+        status = body.get('status')
+        external_id = body.get('external_id', '')
+        if status and external_id:
+            return StatusUpdate(
+                external_id=external_id,
+                status=status,
+                backend=cls.backend,
+                error_code=body.get('error_code', ''),
+            )
+
+        return None
+
+    def listen(self, on_message: Callable[[InboundMessage], None]) -> None:
+        pass
+
+    def stop(self) -> None:
+        pass
+
+    @classmethod
+    def normalize_identity(cls, raw_identity: str) -> str:
+        if raw_identity.startswith('test:'):
+            return raw_identity
+        raise ValueError(f'Test connector expects "test:" prefix: {raw_identity}')
+
+    def _get_config(self) -> dict[str, str]:
+        try:
+            response = requests.get(f'{self._mock_url}/config', timeout=2)
+            return response.json()
+        except requests.RequestException:
+            return {}
+
+    def _report_sent(self, message: OutboundMessage) -> None:
+        try:
+            requests.post(
+                f'{self._mock_url}/sent',
+                json={
+                    'message_uuid': message.message_uuid,
+                    'message_type': message.message_type,
+                    'sender_identity': message.sender_identity,
+                    'recipient_identity': message.recipient_identity,
+                    'body': message.body,
+                },
+                timeout=2,
+            )
+        except requests.RequestException:
+            logger.warning('Failed to report sent message to mock')

--- a/integration_tests/assets/docker-compose.connectors.override.yml
+++ b/integration_tests/assets/docker-compose.connectors.override.yml
@@ -1,0 +1,22 @@
+services:
+  sync:
+    depends_on:
+      - auth
+      - chatd
+      - postgres
+      - rabbitmq
+      - connector-mock
+    environment:
+      TARGETS: "chatd:9304 auth:9497 postgres:5432 rabbitmq:5672 connector-mock:8080"
+
+  chatd:
+    image: wazo-chatd-connectors-test
+    environment:
+      TEST_CONNECTOR_MOCK_URL: 'http://connector-mock:8080'
+    volumes:
+      - ./etc/wazo-chatd/conf.d/70-connectors.yml:/etc/wazo-chatd/conf.d/70-connectors.yml:ro
+
+  connector-mock:
+    image: connector-mock-test
+    ports:
+      - '8080'

--- a/integration_tests/assets/etc/wazo-chatd/conf.d/70-connectors.yml
+++ b/integration_tests/assets/etc/wazo-chatd/conf.d/70-connectors.yml
@@ -1,0 +1,3 @@
+connectors:
+  test:
+    enabled: true

--- a/integration_tests/docker/Dockerfile-chatd-connectors
+++ b/integration_tests/docker/Dockerfile-chatd-connectors
@@ -1,0 +1,4 @@
+FROM wazo-chatd-test
+
+COPY assets/connectors/test-connector /usr/src/test-connector
+RUN python3 -m pip install -e /usr/src/test-connector

--- a/integration_tests/docker/Dockerfile-connector-mock
+++ b/integration_tests/docker/Dockerfile-connector-mock
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+RUN pip install flask
+
+COPY assets/connectors/servers /usr/local/share/connector_mock
+
+EXPOSE 8080
+CMD ["python3", "-u", "/usr/local/share/connector_mock/test-connector-server.py", "8080"]

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import pytest
@@ -49,6 +49,15 @@ def teams():
         yield
     finally:
         asset.TeamsAssetLaunchingTestCase.tearDownClass()
+
+
+@pytest.fixture(scope='session')
+def connectors():
+    asset.ConnectorAssetLaunchingTestCase.setUpClass()
+    try:
+        yield
+    finally:
+        asset.ConnectorAssetLaunchingTestCase.tearDownClass()
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -33,6 +33,7 @@ from wazo_chatd.database.queries import DAO
 from .amid import AmidClient
 from .bus import BusClient
 from .confd import ConfdClient
+from .connector import ConnectorMockClient
 from .microsoft import MicrosoftGraphClient
 from .wait_strategy import (
     EverythingOkWaitStrategy,
@@ -240,6 +241,20 @@ class TeamsAssetLaunchingTestCase(_BaseAssetLaunchingTestCase):
         return MicrosoftGraphClient('127.0.0.1', port=port)
 
 
+class ConnectorAssetLaunchingTestCase(_BaseAssetLaunchingTestCase):
+    asset = 'connectors'
+    service = 'chatd'
+    wait_strategy = EverythingOkWaitStrategy()
+
+    @classmethod
+    def make_connector_mock(cls):
+        try:
+            port = cls.service_port(8080, 'connector-mock')
+        except (NoSuchService, NoSuchPort):
+            return WrongClient('connector-mock')
+        return ConnectorMockClient('127.0.0.1', port=port)
+
+
 class InitAssetLaunchingTestCase(_BaseAssetLaunchingTestCase):
     asset = 'initialization'
     service = 'chatd'
@@ -439,6 +454,25 @@ class InitIntegrationTest(_BaseIntegrationTest):
 
         requests = self.auth.list_requests()['requests']
         assert_that(requests, not_(has_items(has_entries(path='/0.1/sessions'))))
+
+
+class ConnectorIntegrationTest(_BaseIntegrationTest):
+    asset_cls = ConnectorAssetLaunchingTestCase
+    connector_mock: ConnectorMockClient
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reset_clients()
+        cls.auth.set_external_config(
+            {
+                'test': {'mock_url': 'http://connector-mock:8080'},
+            }
+        )
+
+    @classmethod
+    def reset_clients(cls):
+        super().reset_clients()
+        cls.connector_mock = cls.asset_cls.make_connector_mock()
 
 
 class TeamsIntegrationTest(_BaseIntegrationTest):

--- a/integration_tests/suite/helpers/connector.py
+++ b/integration_tests/suite/helpers/connector.py
@@ -1,0 +1,40 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import requests
+
+
+class ConnectorMockClient:
+    def __init__(self, host: str, port: int) -> None:
+        self._base_url = f'http://{host}:{port}'
+
+    def set_config(
+        self,
+        send_behavior: str = 'succeed',
+        external_id: str = '',
+        error_message: str = 'Test connector failure',
+    ) -> None:
+        requests.put(
+            f'{self._base_url}/config',
+            json={
+                'send_behavior': send_behavior,
+                'external_id': external_id,
+                'error_message': error_message,
+            },
+        )
+
+    def get_sent_messages(self) -> list[dict[str, str]]:
+        response = requests.get(f'{self._base_url}/sent')
+        return response.json()
+
+    def reset(self) -> None:
+        requests.post(f'{self._base_url}/reset')
+
+    def is_up(self) -> bool:
+        try:
+            response = requests.get(f'{self._base_url}/config', timeout=2)
+            return response.status_code == 200
+        except requests.RequestException:
+            return False

--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_test_helpers.wait_strategy import (

--- a/integration_tests/suite/test_connector_bus_events.py
+++ b/integration_tests/suite/test_connector_bus_events.py
@@ -1,0 +1,159 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import uuid
+
+import requests
+from wazo_test_helpers import until
+
+from .helpers import fixtures
+from .helpers.base import TOKEN_USER_UUID, ConnectorIntegrationTest, use_asset
+
+EXTERNAL_IDENTITY = 'test:+15559876'
+SENDER_IDENTITY = 'test:+15551234'
+RECIPIENT_UUID = uuid.uuid4()
+
+
+@use_asset('connectors')
+class TestOutboundMessageEvent(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_outbound_message_emits_event_with_type_and_backend(
+        self, user, identity, room
+    ):
+        accumulator = self.bus.accumulator(
+            headers={'name': 'chatd_user_room_message_created'}
+        )
+
+        self.connector_mock.reset()
+        self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Outbound event', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        def event_received():
+            events = accumulator.accumulate(with_headers=True)
+            matching = [
+                e
+                for e in events
+                if e['message']['data'].get('content') == 'Outbound event'
+            ]
+            assert len(matching) >= 1
+            data = matching[0]['message']['data']
+            delivery = data['delivery']
+            assert delivery['type'] == 'test'
+            assert delivery['backend'] == 'test'
+
+        until.assert_(event_received, timeout=5, interval=0.1)
+
+
+@use_asset('connectors')
+class TestInboundMessageEvent(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    def test_inbound_webhook_emits_message_event_with_delivery(self, user, identity):
+        accumulator = self.bus.accumulator(
+            headers={'name': 'chatd_user_room_message_created'}
+        )
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'from': EXTERNAL_IDENTITY,
+                'to': SENDER_IDENTITY,
+                'body': 'Inbound event test',
+                'message_id': f'ext-bus-{uuid.uuid4()}',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def event_received():
+            events = accumulator.accumulate(with_headers=True)
+            assert len(events) >= 1
+            data = events[0]['message']['data']
+            assert data['content'] == 'Inbound event test'
+            delivery = data['delivery']
+            assert delivery['type'] == 'test'
+            assert delivery['backend'] == 'test'
+            assert delivery['status'] == 'delivered'
+
+        until.assert_(event_received, timeout=5, interval=0.1)
+
+
+@use_asset('connectors')
+class TestDeliveryStatusEvent(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_delivery_status_emits_event(self, user, identity, room):
+        accumulator = self.bus.accumulator(
+            headers={'name': 'chatd_message_delivery_status'}
+        )
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-bus-status-001'
+        )
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Track delivery', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        def sent_event_received():
+            events = accumulator.accumulate(with_headers=True)
+            sent = [e for e in events if e['message']['data'].get('status') == 'sent']
+            assert len(sent) >= 1
+            data = sent[0]['message']['data']
+            assert data['message_uuid'] == message['uuid']
+            assert data['backend'] == 'test'
+
+        until.assert_(sent_event_received, timeout=5, interval=0.1)
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'external_id': 'ext-bus-status-001',
+                'status': 'delivered',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+
+        def delivered_event_received():
+            events = accumulator.accumulate(with_headers=True)
+            delivered = [
+                e for e in events if e['message']['data'].get('status') == 'delivered'
+            ]
+            assert len(delivered) >= 1
+            data = delivered[0]['message']['data']
+            assert data['message_uuid'] == message['uuid']
+
+        until.assert_(delivered_event_received, timeout=5, interval=0.1)

--- a/integration_tests/suite/test_connector_delivery.py
+++ b/integration_tests/suite/test_connector_delivery.py
@@ -1,0 +1,795 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import requests
+from wazo_test_helpers import until
+
+from wazo_chatd.database.models import DeliveryRecord, MessageMeta, RoomMessage
+
+from .helpers import fixtures
+from .helpers.base import (
+    TOKEN_TENANT_UUID,
+    TOKEN_USER_UUID,
+    ConnectorIntegrationTest,
+    use_asset,
+)
+
+USER_UUID_1 = uuid.uuid4()
+USER_UUID_2 = uuid.uuid4()
+EXTERNAL_IDENTITY = 'test:+15559876'
+
+
+@use_asset('connectors')
+class TestInboundWebhook(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15551234',
+    )
+    def test_webhook_creates_message_with_meta(self, user, identity):
+
+        webhook_data = {
+            'from': EXTERNAL_IDENTITY,
+            'to': 'test:+15551234',
+            'body': 'Hello from outside',
+            'message_id': 'ext-msg-001',
+        }
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json=webhook_data,
+            headers={'X-Test-Connector': 'true'},
+        )
+
+        assert response.status_code == 204
+
+        def message_persisted():
+            message = (
+                self._session.query(RoomMessage)
+                .filter(RoomMessage.content == 'Hello from outside')
+                .first()
+            )
+            assert message is not None
+
+            meta = (
+                self._session.query(MessageMeta)
+                .filter(MessageMeta.message_uuid == message.uuid)
+                .first()
+            )
+            assert meta is not None
+            assert meta.backend == 'test'
+            assert meta.type_ == 'test'
+
+        until.assert_(message_persisted, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15551234',
+    )
+    def test_webhook_with_backend_hint(self, user, identity):
+
+        webhook_data = {
+            'from': EXTERNAL_IDENTITY,
+            'to': 'test:+15551234',
+            'body': 'Hello with hint',
+            'message_id': 'ext-msg-002',
+        }
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming/test',
+            json=webhook_data,
+            headers={'X-Test-Connector': 'true'},
+        )
+
+        assert response.status_code == 204
+
+        def message_persisted():
+            message = (
+                self._session.query(RoomMessage)
+                .filter(RoomMessage.content == 'Hello with hint')
+                .first()
+            )
+            assert message is not None
+
+        until.assert_(message_persisted, timeout=5, interval=0.1)
+
+    def test_webhook_unknown_connector_returns_404(self):
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={'body': 'hello'},
+            headers={'Content-Type': 'application/json'},
+        )
+
+        assert response.status_code == 404
+
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15551234',
+    )
+    def test_webhook_duplicate_idempotency_skipped(self, user, identity):
+
+        webhook_data = {
+            'from': EXTERNAL_IDENTITY,
+            'to': 'test:+15551234',
+            'body': 'Dedup test',
+            'message_id': 'ext-msg-dedup',
+            'idempotency_key': 'unique-key-001',
+        }
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json=webhook_data,
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def first_message_persisted():
+            messages = (
+                self._session.query(RoomMessage)
+                .filter(RoomMessage.content == 'Dedup test')
+                .all()
+            )
+            assert len(messages) == 1
+
+        until.assert_(first_message_persisted, timeout=5, interval=0.1)
+
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json=webhook_data,
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def still_one_message():
+            messages = (
+                self._session.query(RoomMessage)
+                .filter(RoomMessage.content == 'Dedup test')
+                .all()
+            )
+            assert len(messages) == 1
+
+        until.assert_(still_one_message, timeout=3, interval=0.1)
+
+
+@use_asset('connectors')
+class TestOutboundDelivery(ConnectorIntegrationTest):
+    def _assert_delivery_status(self, message_uuid: str, expected_status: str) -> None:
+        def check():
+            records = (
+                self._session.query(DeliveryRecord)
+                .filter(DeliveryRecord.message_uuid == message_uuid)
+                .order_by(DeliveryRecord.timestamp)
+                .all()
+            )
+            statuses = [r.status for r in records]
+            assert expected_status in statuses
+
+        until.assert_(check, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_message_in_external_room_creates_delivery_records(
+        self, user, identity, room
+    ):
+
+        self.connector_mock.reset()
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Hello external', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        self._assert_delivery_status(message['uuid'], 'sent')
+
+        meta = (
+            self._session.query(MessageMeta)
+            .filter(MessageMeta.message_uuid == message['uuid'])
+            .first()
+        )
+        assert meta is not None
+        assert meta.backend == 'test'
+        assert meta.type_ == 'test'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_connector_mock_receives_sent_message(self, user, identity, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed',
+            external_id='mock-ext-123',
+        )
+
+        self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Check the mock', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        def mock_received():
+            sent = self.connector_mock.get_sent_messages()
+            assert len(sent) >= 1
+            assert sent[0]['body'] == 'Check the mock'
+
+        until.assert_(mock_received, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_failed_delivery_creates_failed_record(self, user, identity, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(send_behavior='fail', error_message='API down')
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Will fail', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        self._assert_delivery_status(message['uuid'], 'failed')
+
+
+@use_asset('connectors')
+class TestStatusUpdate(ConnectorIntegrationTest):
+    def _assert_delivery_status(self, message_uuid: str, expected_status: str) -> None:
+        def check():
+            records = (
+                self._session.query(DeliveryRecord)
+                .filter(DeliveryRecord.message_uuid == message_uuid)
+                .order_by(DeliveryRecord.timestamp)
+                .all()
+            )
+            statuses = [r.status for r in records]
+            assert expected_status in statuses
+
+        until.assert_(check, timeout=5, interval=0.1)
+
+    def _get_external_id(self, message_uuid: str) -> str:
+        def check():
+            meta = (
+                self._session.query(MessageMeta)
+                .filter(MessageMeta.message_uuid == message_uuid)
+                .first()
+            )
+            assert meta is not None
+            assert meta.external_id is not None
+            return meta.external_id
+
+        return until.return_(check, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_delivered_status_creates_record(self, user, identity, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-status-001'
+        )
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Track this', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        self._assert_delivery_status(message['uuid'], 'sent')
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'external_id': 'ext-status-001',
+                'status': 'delivered',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        self._assert_delivery_status(message['uuid'], 'delivered')
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_failed_status_creates_record_with_reason(self, user, identity, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-status-002'
+        )
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {
+                'content': 'Will get failed status',
+                'sender_identity_uuid': str(identity.uuid),
+            },
+        )
+
+        self._assert_delivery_status(message['uuid'], 'sent')
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'external_id': 'ext-status-002',
+                'status': 'failed',
+                'error_code': '30003',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def has_failed_with_reason():
+            records = (
+                self._session.query(DeliveryRecord)
+                .filter(DeliveryRecord.message_uuid == message['uuid'])
+                .order_by(DeliveryRecord.timestamp)
+                .all()
+            )
+            failed = [r for r in records if r.status == 'failed']
+            assert len(failed) >= 1
+            assert failed[0].reason == '30003'
+
+        until.assert_(has_failed_with_reason, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_transient_status_is_ignored(self, user, identity, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-status-003'
+        )
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Transient status', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        self._assert_delivery_status(message['uuid'], 'sent')
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'external_id': 'ext-status-003',
+                'status': 'queued',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def no_queued_record():
+            records = (
+                self._session.query(DeliveryRecord)
+                .filter(DeliveryRecord.message_uuid == message['uuid'])
+                .order_by(DeliveryRecord.timestamp)
+                .all()
+            )
+            statuses = [r.status for r in records]
+            assert 'queued' not in statuses
+
+        until.assert_(no_queued_record, timeout=3, interval=0.1)
+
+
+@use_asset('connectors')
+class TestMultiChannelRoom(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_full_multichannel_flow(self, user_a, user_b, identity_a, identity_b, room):
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-outbound-001'
+        )
+
+        room_uuid = room['uuid']
+        port = self.asset_cls.service_port(9304, 'chatd')
+
+        self.chatd.rooms.create_message_from_user(
+            room_uuid, {'content': 'Internal hello'}
+        )
+
+        self.chatd.rooms.create_message_from_user(
+            room_uuid,
+            {'content': 'Sending by SMS', 'sender_identity_uuid': str(identity_a.uuid)},
+        )
+
+        def mock_received_outbound():
+            sent = self.connector_mock.get_sent_messages()
+            assert any(m['body'] == 'Sending by SMS' for m in sent)
+
+        until.assert_(mock_received_outbound, timeout=5, interval=0.1)
+
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'from': 'test:+15559876',
+                'to': 'test:+15551234',
+                'body': 'SMS reply from user B',
+                'message_id': 'ext-msg-multichannel',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        def all_messages_in_same_room():
+            messages = (
+                self._session.query(RoomMessage)
+                .filter(RoomMessage.room_uuid == room_uuid)
+                .all()
+            )
+            contents = [m.content for m in messages]
+            assert 'Internal hello' in contents
+            assert 'Sending by SMS' in contents
+            assert 'SMS reply from user B' in contents
+
+        until.assert_(all_messages_in_same_room, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_inbound_echo_of_outbound_is_dropped(
+        self, user_a, user_b, identity_a, identity_b, room
+    ):
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-echo-001'
+        )
+
+        room_uuid = room['uuid']
+        port = self.asset_cls.service_port(9304, 'chatd')
+
+        self.chatd.rooms.create_message_from_user(
+            room_uuid,
+            {
+                'content': 'Echo test message',
+                'sender_identity_uuid': str(identity_a.uuid),
+            },
+        )
+
+        def outbound_sent():
+            sent = self.connector_mock.get_sent_messages()
+            assert any(m['body'] == 'Echo test message' for m in sent)
+
+        until.assert_(outbound_sent, timeout=5, interval=0.1)
+
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'from': 'test:+15551234',
+                'to': 'test:+15559876',
+                'body': 'Echo test message',
+                'message_id': 'ext-echo-inbound',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        time.sleep(1)
+
+        messages = (
+            self._session.query(RoomMessage)
+            .filter(RoomMessage.room_uuid == room_uuid)
+            .all()
+        )
+        echo_messages = [m for m in messages if m.content == 'Echo test message']
+        assert len(echo_messages) == 1
+
+
+@use_asset('connectors')
+class TestMessageSchemaFields(ConnectorIntegrationTest):
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4()},
+        ],
+        messages=[{'content': 'internal message', 'user_uuid': TOKEN_USER_UUID}],
+    )
+    def test_internal_message_has_type_internal(self, room):
+        messages = self.chatd.rooms.list_messages_from_user(str(room.uuid))
+
+        message = messages['items'][0]
+        assert message['delivery']['type'] == 'internal'
+        assert message['delivery']['backend'] is None
+        assert message['delivery']['status'] == 'delivered'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_connector_message_has_type_from_identity(self, user, identity, room):
+        self.connector_mock.reset()
+
+        self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'Typed message', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        def message_has_type():
+            messages = self.chatd.rooms.list_messages_from_user(str(room.uuid))
+            connector_msgs = [
+                m for m in messages['items'] if m['content'] == 'Typed message'
+            ]
+            assert len(connector_msgs) == 1
+            assert connector_msgs[0]['delivery']['type'] == 'test'
+            assert connector_msgs[0]['delivery']['backend'] == 'test'
+
+        until.assert_(message_has_type, timeout=5, interval=0.1)
+
+
+@use_asset('connectors')
+class TestMessageVisibility(ConnectorIntegrationTest):
+    def _make_user_b_client(self):
+        token_b = self.asset_cls.create_user_token(
+            str(USER_UUID_1), str(TOKEN_TENANT_UUID)
+        )
+        return self.asset_cls.make_chatd(token=token_b)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_sender_sees_own_pending_message(
+        self, user_a, user_b, identity_a, identity_b, room
+    ):
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-vis-001'
+        )
+
+        self.chatd.rooms.create_message_from_user(
+            room['uuid'],
+            {
+                'content': 'Visible to sender',
+                'sender_identity_uuid': str(identity_a.uuid),
+            },
+        )
+
+        messages = self.chatd.rooms.list_messages_from_user(room['uuid'])
+        contents = [m['content'] for m in messages['items']]
+        assert 'Visible to sender' in contents
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_other_user_does_not_see_pending_message(
+        self, user_a, user_b, identity_a, identity_b, room
+    ):
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-vis-002'
+        )
+
+        self.chatd.rooms.create_message_from_user(
+            room['uuid'],
+            {
+                'content': 'Not yet visible',
+                'sender_identity_uuid': str(identity_a.uuid),
+            },
+        )
+
+        chatd_b = self._make_user_b_client()
+        messages = chatd_b.rooms.list_messages_from_user(room['uuid'])
+        contents = [m['content'] for m in messages['items']]
+        assert 'Not yet visible' not in contents
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_other_user_sees_message_after_delivery(
+        self, user_a, user_b, identity_a, identity_b, room
+    ):
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-vis-003'
+        )
+
+        self.chatd.rooms.create_message_from_user(
+            room['uuid'],
+            {
+                'content': 'Will be delivered',
+                'sender_identity_uuid': str(identity_a.uuid),
+            },
+        )
+
+        def sent():
+            records = (
+                self._session.query(DeliveryRecord)
+                .join(MessageMeta)
+                .join(RoomMessage)
+                .filter(RoomMessage.content == 'Will be delivered')
+                .all()
+            )
+            statuses = [r.status for r in records]
+            assert 'sent' in statuses
+
+        until.assert_(sent, timeout=5, interval=0.1)
+
+        port = self.asset_cls.service_port(9304, 'chatd')
+        requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={'external_id': 'ext-vis-003', 'status': 'delivered'},
+            headers={'X-Test-Connector': 'true'},
+        )
+
+        chatd_b = self._make_user_b_client()
+
+        def visible_to_b():
+            messages = chatd_b.rooms.list_messages_from_user(room['uuid'])
+            contents = [m['content'] for m in messages['items']]
+            assert 'Will be delivered' in contents
+
+        until.assert_(visible_to_b, timeout=5, interval=0.1)
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_1)},
+        ],
+    )
+    def test_internal_message_visible_to_all(self, user_a, user_b, room):
+        self.chatd.rooms.create_message_from_user(
+            room['uuid'], {'content': 'Internal hello'}
+        )
+
+        chatd_b = self._make_user_b_client()
+        messages = chatd_b.rooms.list_messages_from_user(room['uuid'])
+        contents = [m['content'] for m in messages['items']]
+        assert 'Internal hello' in contents

--- a/integration_tests/suite/test_connector_user_identity.py
+++ b/integration_tests/suite/test_connector_user_identity.py
@@ -1,0 +1,221 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import requests
+from wazo_chatd_client.exceptions import ChatdError
+
+from .helpers import fixtures
+from .helpers.base import TOKEN_SUBTENANT_UUID as OTHER_TENANT_UUID
+from .helpers.base import TOKEN_TENANT_UUID, ConnectorIntegrationTest, use_asset
+
+USER_UUID = uuid.uuid4()
+OTHER_TENANT_USER_UUID = uuid.uuid4()
+
+
+def _identity_url(port: int, user_uuid: str) -> str:
+    return f'http://127.0.0.1:{port}/1.0/users/{user_uuid}/identities'
+
+
+@use_asset('connectors')
+class TestUserIdentityCRUD(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_list_empty(self, user):
+        result = self.chatd.user_identities.list(str(USER_UUID))
+
+        assert result['items'] == []
+        assert result['total'] == 0
+
+    @fixtures.db.user(uuid=USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15551234567',
+    )
+    def test_list_returns_identities(self, user, identity):
+        result = self.chatd.user_identities.list(str(USER_UUID))
+
+        assert result['total'] == 1
+        assert result['items'][0]['backend'] == 'twilio'
+        assert result['items'][0]['type'] == 'sms'
+        assert result['items'][0]['identity'] == '+15551234567'
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_create(self, user):
+        result = self.chatd.user_identities.create(
+            str(USER_UUID),
+            {'backend': 'twilio', 'type': 'sms', 'identity': '+15559999999'},
+        )
+
+        assert result['backend'] == 'twilio'
+        assert result['type'] == 'sms'
+        assert result['identity'] == '+15559999999'
+        assert 'uuid' in result
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_create_with_extra(self, user):
+        result = self.chatd.user_identities.create(
+            str(USER_UUID),
+            {
+                'backend': 'twilio',
+                'type': 'sms',
+                'identity': '+15558888888',
+                'extra': {'account_sid': 'AC123'},
+            },
+        )
+
+        assert result['type'] == 'sms'
+        assert result['extra'] == {'account_sid': 'AC123'}
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_create_missing_backend_returns_400(self, user):
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.user_identities.create(
+                str(USER_UUID),
+                {'type': 'sms', 'identity': '+15557777777'},
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_create_missing_identity_returns_400(self, user):
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.user_identities.create(
+                str(USER_UUID),
+                {'backend': 'twilio', 'type': 'sms'},
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @fixtures.db.user(uuid=USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15551234567',
+    )
+    def test_get(self, user, identity):
+        result = self.chatd.user_identities.get(str(USER_UUID), str(identity.uuid))
+
+        assert result['uuid'] == str(identity.uuid)
+        assert result['backend'] == 'twilio'
+        assert result['type'] == 'sms'
+        assert result['identity'] == '+15551234567'
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_get_unknown_returns_404(self, user):
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.user_identities.get(str(USER_UUID), str(uuid.uuid4()))
+
+        assert exc_info.value.status_code == 404
+
+    @fixtures.db.user(uuid=USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15551234567',
+    )
+    def test_update(self, user, identity):
+        self.chatd.user_identities.update(
+            str(USER_UUID),
+            str(identity.uuid),
+            {'backend': 'vonage', 'type': 'sms', 'identity': '+15550000000'},
+        )
+
+    @fixtures.db.user(uuid=USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15551234567',
+    )
+    def test_delete(self, user, identity):
+        identity_uuid = str(identity.uuid)
+
+        self.chatd.user_identities.delete(str(USER_UUID), identity_uuid)
+
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.user_identities.get(str(USER_UUID), identity_uuid)
+
+        assert exc_info.value.status_code == 404
+
+    @fixtures.db.user(uuid=USER_UUID)
+    def test_delete_unknown_returns_404(self, user):
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.user_identities.delete(str(USER_UUID), str(uuid.uuid4()))
+
+        assert exc_info.value.status_code == 404
+
+
+@use_asset('connectors')
+class TestUserIdentityAuth(ConnectorIntegrationTest):
+    @property
+    def port(self) -> int:
+        return self.asset_cls.service_port(9304, 'chatd')
+
+    def test_no_token_returns_401(self):
+        response = requests.get(
+            _identity_url(self.port, str(USER_UUID)),
+            headers={'Content-Type': 'application/json'},
+        )
+
+        assert response.status_code == 401
+
+    def test_invalid_token_returns_401(self):
+        response = requests.get(
+            _identity_url(self.port, str(USER_UUID)),
+            headers={
+                'X-Auth-Token': str(uuid.uuid4()),
+                'Content-Type': 'application/json',
+            },
+        )
+
+        assert response.status_code == 401
+
+    @fixtures.db.user(uuid=OTHER_TENANT_USER_UUID, tenant_uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=OTHER_TENANT_USER_UUID,
+        tenant_uuid=OTHER_TENANT_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15553334444',
+    )
+    def test_token_sees_own_tenant_identities(self, user, identity):
+        token = self.asset_cls.create_user_token(
+            str(OTHER_TENANT_USER_UUID), str(OTHER_TENANT_UUID)
+        )
+        chatd = self.asset_cls.make_chatd(token=token)
+
+        result = chatd.user_identities.list(
+            str(OTHER_TENANT_USER_UUID), tenant_uuid=str(OTHER_TENANT_UUID)
+        )
+
+        assert result['total'] == 1
+        assert result['items'][0]['identity'] == '+15553334444'
+
+    @fixtures.db.user(uuid=USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID,
+        tenant_uuid=TOKEN_TENANT_UUID,
+        backend='twilio',
+        type_='sms',
+        identity='+15551112222',
+    )
+    def test_user_identity_tenant_isolation(self, user, identity):
+        other_token = self.asset_cls.create_user_token(
+            str(OTHER_TENANT_USER_UUID), str(OTHER_TENANT_UUID)
+        )
+        chatd = self.asset_cls.make_chatd(token=other_token)
+
+        with pytest.raises(ChatdError) as exc_info:
+            chatd.user_identities.list(
+                str(USER_UUID), tenant_uuid=str(TOKEN_TENANT_UUID)
+            )
+
+        assert exc_info.value.status_code == 401

--- a/integration_tests/suite/test_connector_validation.py
+++ b/integration_tests/suite/test_connector_validation.py
@@ -1,0 +1,256 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from wazo_chatd_client.exceptions import ChatdError
+
+from .helpers import fixtures
+from .helpers.base import TOKEN_USER_UUID, ConnectorIntegrationTest, use_asset
+
+EXTERNAL_IDENTITY = 'test:+15559876'
+EXTERNAL_IDENTITY_2 = 'test:+15558765'
+UNREACHABLE_IDENTITY = 'unreachable:+15559876'
+INTERNAL_USER_UUID = uuid.uuid4()
+RECIPIENT_USER_UUID = uuid.uuid4()
+
+
+@use_asset('connectors')
+class TestRoomCreationValidation(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    def test_room_with_unreachable_participant_returns_409(self, user):
+
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.rooms.create_from_user(
+                {
+                    'users': [
+                        {'uuid': str(TOKEN_USER_UUID)},
+                        {'uuid': str(uuid.uuid4()), 'identity': UNREACHABLE_IDENTITY},
+                    ],
+                }
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.error_id == 'unreachable-participant'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    def test_room_with_reachable_external_participant_succeeds(self, user, identity):
+
+        room = self.chatd.rooms.create_from_user(
+            {
+                'users': [
+                    {'uuid': str(TOKEN_USER_UUID)},
+                    {'uuid': str(uuid.uuid4()), 'identity': EXTERNAL_IDENTITY},
+                ],
+            }
+        )
+
+        assert room['uuid'] is not None
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    def test_room_with_multiple_reachable_external_participants(self, user, identity):
+
+        room = self.chatd.rooms.create_from_user(
+            {
+                'users': [
+                    {'uuid': str(TOKEN_USER_UUID)},
+                    {'uuid': str(uuid.uuid4()), 'identity': EXTERNAL_IDENTITY},
+                    {'uuid': str(uuid.uuid4()), 'identity': EXTERNAL_IDENTITY_2},
+                ],
+            }
+        )
+
+        assert room['uuid'] is not None
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    def test_room_with_one_reachable_one_unreachable_returns_409(self, user):
+
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.rooms.create_from_user(
+                {
+                    'users': [
+                        {'uuid': str(TOKEN_USER_UUID)},
+                        {'uuid': str(uuid.uuid4()), 'identity': EXTERNAL_IDENTITY},
+                        {'uuid': str(uuid.uuid4()), 'identity': UNREACHABLE_IDENTITY},
+                    ],
+                }
+            )
+
+        assert exc_info.value.status_code == 409
+
+    def test_internal_only_room_succeeds(self):
+        room = self.chatd.rooms.create_from_user(
+            {
+                'users': [
+                    {'uuid': str(TOKEN_USER_UUID)},
+                    {'uuid': str(uuid.uuid4())},
+                ],
+            }
+        )
+
+        assert room['uuid'] is not None
+
+
+@use_asset('connectors')
+class TestMessageValidation(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_external_room_without_sender_identity_uuid_returns_409(
+        self, user, identity, room
+    ):
+
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.rooms.create_message_from_user(
+                str(room.uuid), {'content': 'No alias'}
+            )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.error_id == 'message-identity-required'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_external_room_with_sender_identity_uuid_succeeds(
+        self, user, identity, room
+    ):
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {'content': 'With alias', 'sender_identity_uuid': str(identity.uuid)},
+        )
+
+        assert message['content'] == 'With alias'
+
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': uuid.uuid4()},
+        ],
+    )
+    def test_internal_room_without_sender_identity_uuid_succeeds(self, room):
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid), {'content': 'Internal message'}
+        )
+
+        assert message['content'] == 'Internal message'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=RECIPIENT_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=RECIPIENT_USER_UUID,
+        backend='test',
+        identity='test:+15559999',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': RECIPIENT_USER_UUID},
+        ],
+    )
+    def test_internal_room_with_sender_identity_uuid_succeeds(
+        self, user, recipient, sender_identity, recipient_identity, room
+    ):
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {
+                'content': 'Internal with alias',
+                'sender_identity_uuid': str(sender_identity.uuid),
+            },
+        )
+
+        assert message['content'] == 'Internal with alias'
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': INTERNAL_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_mixed_room_without_sender_identity_uuid_returns_409(
+        self, user, identity, room
+    ):
+
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.rooms.create_message_from_user(
+                str(room.uuid), {'content': 'Mixed room no alias'}
+            )
+
+        assert exc_info.value.status_code == 409
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=INTERNAL_USER_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=INTERNAL_USER_UUID,
+        backend='test',
+        identity='test:+15558888',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': INTERNAL_USER_UUID},
+            {'uuid': uuid.uuid4(), 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_mixed_room_with_sender_identity_uuid_succeeds(
+        self, user, internal_user, sender_identity, internal_identity, room
+    ):
+
+        message = self.chatd.rooms.create_message_from_user(
+            str(room.uuid),
+            {
+                'content': 'Mixed room with alias',
+                'sender_identity_uuid': str(sender_identity.uuid),
+            },
+        )
+
+        assert message['content'] == 'Mixed room with alias'

--- a/integration_tests/suite/test_db_message_meta.py
+++ b/integration_tests/suite/test_db_message_meta.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Integration tests for MessageMeta and DeliveryRecord models."""
+
+from __future__ import annotations
+
+from wazo_chatd.database.models import DeliveryRecord, MessageMeta, Room
+
+from .helpers import fixtures
+from .helpers.base import DBIntegrationTest, use_asset
+
+
+@use_asset('database')
+class TestMessageMeta(DBIntegrationTest):
+    @fixtures.db.room(messages=[{'content': 'hello'}])
+    def test_message_meta_created_with_message(self, room):
+        message = room.messages[0]
+
+        meta = MessageMeta(
+            message_uuid=message.uuid,
+            type_='sms',
+            backend='twilio',
+        )
+        self._session.add(meta)
+        self._session.flush()
+
+        self._session.refresh(message)
+        assert message.meta is not None
+        assert message.meta.type_ == 'sms'
+        assert message.meta.backend == 'twilio'
+
+    @fixtures.db.room(messages=[{'content': 'internal msg'}])
+    def test_message_without_meta(self, room):
+        message = room.messages[0]
+        assert message.meta is None
+
+    @fixtures.db.room(messages=[{'content': 'tracked'}])
+    def test_meta_with_delivery_records(self, room):
+        message = room.messages[0]
+
+        meta = MessageMeta(
+            message_uuid=message.uuid,
+            type_='sms',
+            backend='twilio',
+        )
+        self._session.add(meta)
+        self._session.flush()
+
+        record_1 = DeliveryRecord(
+            message_uuid=message.uuid,
+            status='pending',
+        )
+        record_2 = DeliveryRecord(
+            message_uuid=message.uuid,
+            status='sending',
+        )
+        record_3 = DeliveryRecord(
+            message_uuid=message.uuid,
+            status='sent',
+        )
+        self._session.add_all([record_1, record_2, record_3])
+        self._session.flush()
+
+        self._session.refresh(meta)
+        assert len(meta.records) == 3
+        assert meta.status == 'sent'
+
+    @fixtures.db.room(messages=[{'content': 'fail'}])
+    def test_meta_with_failed_delivery(self, room):
+        message = room.messages[0]
+
+        meta = MessageMeta(
+            message_uuid=message.uuid,
+            type_='sms',
+            backend='twilio',
+            retry_count=3,
+        )
+        self._session.add(meta)
+        self._session.flush()
+
+        record = DeliveryRecord(
+            message_uuid=message.uuid,
+            status='dead_letter',
+            reason='Max retries exceeded',
+        )
+        self._session.add(record)
+        self._session.flush()
+
+        self._session.refresh(meta)
+        assert meta.status == 'dead_letter'
+        assert meta.records[0].reason == 'Max retries exceeded'
+
+    @fixtures.db.room(messages=[{'content': 'extra data'}])
+    def test_meta_extra_jsonb(self, room):
+        message = room.messages[0]
+
+        meta = MessageMeta(
+            message_uuid=message.uuid,
+            backend='twilio',
+            extra={
+                'idempotency_key': 'idem-123',
+                'account_sid': 'AC123',
+            },
+        )
+        self._session.add(meta)
+        self._session.flush()
+
+        self._session.refresh(meta)
+        assert meta.extra['idempotency_key'] == 'idem-123'
+        assert meta.extra['account_sid'] == 'AC123'
+
+
+@use_asset('database')
+class TestCascadeDeletes(DBIntegrationTest):
+    @fixtures.db.room(messages=[{'content': 'cascade test'}])
+    def test_delete_room_cascades_to_meta_and_records(self, room):
+        message = room.messages[0]
+
+        meta = MessageMeta(
+            message_uuid=message.uuid,
+            type_='sms',
+            backend='twilio',
+        )
+        self._session.add(meta)
+        self._session.flush()
+
+        record = DeliveryRecord(
+            message_uuid=message.uuid,
+            status='sent',
+        )
+        self._session.add(record)
+        self._session.flush()
+
+        message_uuid = message.uuid
+
+        # Delete the room — should cascade to message → meta → records
+        self._session.query(Room).filter(Room.uuid == room.uuid).delete()
+        self._session.flush()
+
+        assert (
+            self._session.query(MessageMeta)
+            .filter(MessageMeta.message_uuid == message_uuid)
+            .first()
+            is None
+        )
+
+        assert (
+            self._session.query(DeliveryRecord)
+            .filter(DeliveryRecord.message_uuid == message_uuid)
+            .first()
+            is None
+        )

--- a/integration_tests/suite/test_db_user_identity.py
+++ b/integration_tests/suite/test_db_user_identity.py
@@ -1,0 +1,116 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import uuid
+
+from wazo_chatd.database.models import Room, RoomUser, UserIdentity
+
+from .helpers import fixtures
+from .helpers.base import TOKEN_TENANT_UUID as TENANT_1
+from .helpers.base import WAZO_UUID, DBIntegrationTest, use_asset
+
+USER_UUID_1 = uuid.uuid4()
+USER_UUID_2 = uuid.uuid4()
+
+
+@use_asset('database')
+class TestUserIdentity(DBIntegrationTest):
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='twilio',
+        type_='sms',
+        identity='+15551234567',
+    )
+    def test_create_identity(self, identity, user):
+        result = (
+            self._session.query(UserIdentity)
+            .filter(UserIdentity.identity == '+15551234567')
+            .first()
+        )
+
+        assert result is not None
+        assert result.user_uuid == USER_UUID_1
+        assert result.backend == 'twilio'
+
+    @fixtures.db.user(uuid=USER_UUID_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='twilio',
+        type_='sms',
+        identity='+15551111111',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        backend='vonage',
+        type_='sms',
+        identity='+15552222222',
+    )
+    def test_user_multiple_identities(
+        self,
+        identity_2,
+        identity_1,
+        user,
+    ):
+        results = (
+            self._session.query(UserIdentity)
+            .filter(UserIdentity.user_uuid == USER_UUID_1)
+            .all()
+        )
+
+        assert len(results) == 2
+
+
+@use_asset('database')
+class TestRoomUserIdentity(DBIntegrationTest):
+    @fixtures.db.room(
+        users=[
+            {'uuid': USER_UUID_1},
+            {'uuid': USER_UUID_2, 'identity': '+15559876543'},
+        ],
+    )
+    def test_room_with_external_participant(self, room):
+        internal_user = next(u for u in room.users if u.uuid == USER_UUID_1)
+        external_user = next(u for u in room.users if u.uuid == USER_UUID_2)
+
+        assert internal_user.identity is None
+        assert external_user.identity == '+15559876543'
+
+    @fixtures.db.room(
+        users=[
+            {'uuid': USER_UUID_1},
+            {'uuid': USER_UUID_2},
+        ],
+    )
+    def test_room_all_internal(self, room):
+        for user in room.users:
+            assert user.identity is None
+
+    def test_query_by_identity(self):
+        ext_uuid = uuid.uuid4()
+        room = Room(tenant_uuid=TENANT_1)
+        room.users = [
+            RoomUser(
+                uuid=ext_uuid,
+                tenant_uuid=TENANT_1,
+                wazo_uuid=WAZO_UUID,
+                identity='+15559999999',
+            ),
+        ]
+        self._session.add(room)
+        self._session.flush()
+
+        results = (
+            self._session.query(RoomUser)
+            .filter(RoomUser.identity == '+15559999999')
+            .all()
+        )
+
+        assert len(results) == 1
+        assert results[0].uuid == ext_uuid
+
+        # cleanup
+        self._session.query(Room).filter(Room.uuid == room.uuid).delete()
+        self._session.commit()

--- a/integration_tests/suite/test_room_identities.py
+++ b/integration_tests/suite/test_room_identities.py
@@ -1,0 +1,88 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from wazo_chatd_client.exceptions import ChatdError
+
+from .helpers import fixtures
+from .helpers.base import TOKEN_USER_UUID, ConnectorIntegrationTest, use_asset
+
+RECIPIENT_UUID = uuid.uuid4()
+EXTERNAL_IDENTITY = 'test:+15559876'
+SENDER_IDENTITY = 'test:+15551234'
+
+
+@use_asset('connectors')
+class TestRoomIdentities(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=RECIPIENT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': RECIPIENT_UUID, 'identity': EXTERNAL_IDENTITY},
+        ],
+    )
+    def test_external_participant_returns_sender_identities(
+        self, sender, recipient, identity, room
+    ):
+        result = self.chatd.rooms.list_available_identities_from_user(str(room.uuid))
+
+        assert result['total'] >= 1
+        identities = [item['identity'] for item in result['items']]
+        assert SENDER_IDENTITY in identities
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=RECIPIENT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.user_identity(
+        user_uuid=RECIPIENT_UUID,
+        backend='test',
+        identity='test:+15557777',
+    )
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': RECIPIENT_UUID},
+        ],
+    )
+    def test_wazo_user_with_identity_returns_sender_identities(
+        self, sender, recipient, sender_identity, recipient_identity, room
+    ):
+        result = self.chatd.rooms.list_available_identities_from_user(str(room.uuid))
+
+        assert result['total'] >= 1
+        identities = [item['identity'] for item in result['items']]
+        assert SENDER_IDENTITY in identities
+
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=RECIPIENT_UUID)
+    @fixtures.db.room(
+        users=[
+            {'uuid': TOKEN_USER_UUID},
+            {'uuid': RECIPIENT_UUID},
+        ],
+    )
+    def test_internal_only_room_returns_empty(self, sender, recipient, room):
+        result = self.chatd.rooms.list_available_identities_from_user(str(room.uuid))
+
+        assert result['total'] == 0
+        assert result['items'] == []
+
+    def test_unknown_room_returns_404(self):
+        with pytest.raises(ChatdError) as exc_info:
+            self.chatd.rooms.list_available_identities_from_user(str(uuid.uuid4()))
+
+        assert exc_info.value.status_code == 404

--- a/wazo_chatd/plugins/connectors/http.py
+++ b/wazo_chatd/plugins/connectors/http.py
@@ -1,0 +1,142 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from flask import request
+from flask_restful import Resource
+from xivo.auth_verifier import required_acl
+from xivo.tenant_flask_helpers import token
+
+from wazo_chatd.database.models import UserIdentity
+from wazo_chatd.http import AuthResource
+from wazo_chatd.plugin_helpers.http import update_model_instance
+from wazo_chatd.plugin_helpers.tenant import get_tenant_uuids
+from wazo_chatd.plugins.connectors.exceptions import ConnectorParseError
+from wazo_chatd.plugins.connectors.schemas import UserIdentitySchema
+from wazo_chatd.plugins.connectors.services import ConnectorService
+from wazo_chatd.plugins.connectors.types import WebhookData
+
+if TYPE_CHECKING:
+    from wazo_chatd.plugins.connectors.router import ConnectorRouter
+
+logger = logging.getLogger(__name__)
+
+
+class ConnectorWebhookResource(Resource):
+    """Shared webhook endpoint for all connector backends.
+
+    Routes:
+        ``POST /connectors/incoming`` — tries all connectors
+        ``POST /connectors/incoming/<backend>`` — backend hint for fast path
+
+    Extracts the request body and HTTP metadata into a
+    :class:`WebhookData`, then dispatches to the router.
+    """
+
+    def __init__(self, router: ConnectorRouter) -> None:
+        self._router = router
+
+    def post(self, backend: str | None = None) -> tuple[dict[str, Any] | str, int]:
+        data = self._build_webhook_data()
+
+        try:
+            self._router.dispatch_webhook(data, backend=backend)
+        except ConnectorParseError:
+            logger.info('No connector matched webhook (backend=%s)', backend)
+            return {'error': 'No connector matched the webhook'}, 404
+
+        return '', 204
+
+    def _build_webhook_data(self) -> WebhookData:
+        if request.is_json:
+            body: dict[str, Any] = request.get_json(force=True) or {}
+        else:
+            body = request.form.to_dict()
+
+        return WebhookData(
+            body=body,
+            headers=dict(request.headers),
+            content_type=request.content_type or '',
+            url=request.url,
+        )
+
+
+class UserIdentityListResource(AuthResource):
+    def __init__(self, service: ConnectorService) -> None:
+        self._service = service
+
+    @required_acl('chatd.users.{user_uuid}.identities.read')
+    def get(self, user_uuid: str) -> tuple[dict[str, Any], int]:
+        tenant_uuids = get_tenant_uuids(recurse=True)
+        identities = self._service.list_identities(tenant_uuids, user_uuid)
+        return {
+            'items': UserIdentitySchema().dump(identities, many=True),
+            'total': len(identities),
+        }, 200
+
+    @required_acl('chatd.users.{user_uuid}.identities.create')
+    def post(self, user_uuid: str) -> tuple[dict[str, Any], int]:
+        tenant_uuids = get_tenant_uuids(recurse=True)
+        body = UserIdentitySchema().load(request.get_json(force=True))
+        tenant_uuid = tenant_uuids[0]
+        identity = UserIdentity(
+            tenant_uuid=tenant_uuid,
+            user_uuid=user_uuid,
+            **body,
+        )
+        created = self._service.create_identity(identity)
+        return UserIdentitySchema().dump(created), 201
+
+
+class UserIdentityItemResource(AuthResource):
+    def __init__(self, service: ConnectorService) -> None:
+        self._service = service
+
+    @required_acl('chatd.users.{user_uuid}.identities.{identity_uuid}.read')
+    def get(self, user_uuid: str, identity_uuid: str) -> tuple[dict[str, Any], int]:
+        tenant_uuids = get_tenant_uuids(recurse=True)
+        identity = self._service.get_identity(
+            tenant_uuids, identity_uuid, user_uuid=user_uuid
+        )
+        return UserIdentitySchema().dump(identity), 200
+
+    @required_acl('chatd.users.{user_uuid}.identities.{identity_uuid}.update')
+    def put(self, user_uuid: str, identity_uuid: str) -> tuple[str, int]:
+        tenant_uuids = get_tenant_uuids(recurse=True)
+        identity = self._service.get_identity(
+            tenant_uuids, identity_uuid, user_uuid=user_uuid
+        )
+        body = UserIdentitySchema().load(request.get_json(force=True))
+        update_model_instance(identity, body)
+        self._service.update_identity(identity)
+        return '', 204
+
+    @required_acl('chatd.users.{user_uuid}.identities.{identity_uuid}.delete')
+    def delete(self, user_uuid: str, identity_uuid: str) -> tuple[str, int]:
+        tenant_uuids = get_tenant_uuids(recurse=True)
+        identity = self._service.get_identity(
+            tenant_uuids, identity_uuid, user_uuid=user_uuid
+        )
+        self._service.delete_identity(identity)
+        return '', 204
+
+
+class RoomIdentityListResource(AuthResource):
+    def __init__(self, service: ConnectorService) -> None:
+        self._service = service
+
+    @required_acl('chatd.users.me.rooms.{room_uuid}.identities.read')
+    def get(self, room_uuid: str) -> tuple[dict[str, Any], int]:
+        identities = self._service.list_room_identities(
+            [token.tenant_uuid], room_uuid, str(token.user_uuid)
+        )
+        return {
+            'items': UserIdentitySchema(
+                only=('uuid', 'backend', 'type_', 'identity')
+            ).dump(identities, many=True),
+            'total': len(identities),
+        }, 200

--- a/wazo_chatd/plugins/connectors/plugin.py
+++ b/wazo_chatd/plugins/connectors/plugin.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import logging
+
+from wazo_auth_client import Client as AuthClient
+
+from wazo_chatd.plugin_helpers.dependencies import PluginDependencies
+from wazo_chatd.plugins.connectors.bus_consume import ConnectorBusEventHandler
+from wazo_chatd.plugins.connectors.http import (
+    RoomIdentityListResource,
+    UserIdentityItemResource,
+    UserIdentityListResource,
+)
+from wazo_chatd.plugins.connectors.notifier import UserIdentityNotifier
+from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+from wazo_chatd.plugins.connectors.router import ConnectorRouter
+from wazo_chatd.plugins.connectors.services import ConnectorService
+
+logger = logging.getLogger(__name__)
+
+
+class Plugin:
+    def load(self, dependencies: PluginDependencies) -> None:
+        config = dependencies['config']
+        api = dependencies['api']
+        dao = dependencies['dao']
+        bus_consumer = dependencies['bus_consumer']
+        bus_publisher = dependencies['bus_publisher']
+        hooks = dependencies['hooks']
+        status_aggregator = dependencies['status_aggregator']
+        thread_manager = dependencies['thread_manager']
+
+        registry = ConnectorRegistry()
+        registry.discover(connectors_config=config.get('connectors', {}))
+
+        auth_client = AuthClient(**config['auth'])
+        token_changed_subscribe = dependencies['token_changed_subscribe']
+        token_changed_subscribe(auth_client.set_token)
+
+        notifier = UserIdentityNotifier(bus_publisher)
+        service = ConnectorService(dao, registry, notifier=notifier)
+
+        router = ConnectorRouter(config, registry, service, auth_client)
+        router.register_http_endpoints(api)
+
+        hooks.register('before_room_creation', router.validate_room_creation)
+        hooks.register('before_message_creation', router.prepare_outbound)
+
+        bus_handler = ConnectorBusEventHandler(bus_consumer, router)
+        bus_handler.subscribe()
+
+        api.add_resource(
+            UserIdentityListResource,
+            '/users/<uuid:user_uuid>/identities',
+            resource_class_args=[service],
+        )
+        api.add_resource(
+            UserIdentityItemResource,
+            '/users/<uuid:user_uuid>/identities/<uuid:identity_uuid>',
+            resource_class_args=[service],
+        )
+
+        api.add_resource(
+            RoomIdentityListResource,
+            '/users/me/rooms/<uuid:room_uuid>/identities',
+            resource_class_args=[service],
+        )
+
+        thread_manager.manage(router)
+        status_aggregator.add_provider(router.provide_status)

--- a/wazo_chatd/plugins/connectors/tests/test_http.py
+++ b/wazo_chatd/plugins/connectors/tests/test_http.py
@@ -1,0 +1,105 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import json
+import unittest
+from unittest.mock import Mock
+
+from flask import Flask
+
+from wazo_chatd.plugins.connectors.exceptions import ConnectorParseError
+from wazo_chatd.plugins.connectors.http import ConnectorWebhookResource
+from wazo_chatd.plugins.connectors.types import WebhookData
+
+
+class TestConnectorWebhookResource(unittest.TestCase):
+    def setUp(self) -> None:
+        self.app = Flask(__name__)
+        self.router = Mock()
+        self.resource = ConnectorWebhookResource(self.router)
+
+    def test_post_json_dispatches_to_router(self) -> None:
+        self.router.dispatch_webhook.return_value = None
+
+        with self.app.test_request_context(
+            '/connectors/incoming/twilio',
+            method='POST',
+            data=json.dumps({'Body': 'hello', 'From': '+15559876'}),
+            content_type='application/json',
+        ):
+            response, status_code = self.resource.post(backend='twilio')
+
+        self.router.dispatch_webhook.assert_called_once()
+        call_args = self.router.dispatch_webhook.call_args
+        data = call_args[0][0]
+        assert isinstance(data, WebhookData)
+        assert data.body['Body'] == 'hello'
+        assert data.body['From'] == '+15559876'
+        assert call_args[1]['backend'] == 'twilio'
+        assert status_code == 204
+
+    def test_post_form_data_dispatches_to_router(self) -> None:
+        self.router.dispatch_webhook.return_value = None
+
+        with self.app.test_request_context(
+            '/connectors/incoming/twilio',
+            method='POST',
+            data='Body=hello&From=%2B15559876',
+            content_type='application/x-www-form-urlencoded',
+        ):
+            response, status_code = self.resource.post(backend='twilio')
+
+        call_args = self.router.dispatch_webhook.call_args
+        data = call_args[0][0]
+        assert isinstance(data, WebhookData)
+        assert data.body['Body'] == 'hello'
+        assert data.body['From'] == '+15559876'
+        assert status_code == 204
+
+    def test_post_without_backend_hint(self) -> None:
+        self.router.dispatch_webhook.return_value = None
+
+        with self.app.test_request_context(
+            '/connectors/incoming',
+            method='POST',
+            data=json.dumps({'Body': 'hello'}),
+            content_type='application/json',
+        ):
+            response, status_code = self.resource.post()
+
+        call_args = self.router.dispatch_webhook.call_args
+        assert call_args[1]['backend'] is None
+        assert status_code == 204
+
+    def test_post_unknown_backend_returns_404(self) -> None:
+        self.router.dispatch_webhook.side_effect = ConnectorParseError('No connector')
+
+        with self.app.test_request_context(
+            '/connectors/incoming/nonexistent',
+            method='POST',
+            data='{}',
+            content_type='application/json',
+        ):
+            response, status_code = self.resource.post(backend='nonexistent')
+
+        assert status_code == 404
+
+    def test_headers_passed_in_webhook_data(self) -> None:
+        self.router.dispatch_webhook.return_value = None
+
+        with self.app.test_request_context(
+            '/connectors/incoming/twilio',
+            method='POST',
+            data=json.dumps({'Body': 'hi'}),
+            content_type='application/json',
+            headers={'X-Custom-Header': 'test-value'},
+        ):
+            self.resource.post(backend='twilio')
+
+        call_args = self.router.dispatch_webhook.call_args
+        data = call_args[0][0]
+        assert isinstance(data, WebhookData)
+        assert data.headers['X-Custom-Header'] == 'test-value'
+        assert data.content_type == 'application/json'

--- a/wazo_chatd/plugins/connectors/tests/test_user_identity.py
+++ b/wazo_chatd/plugins/connectors/tests/test_user_identity.py
@@ -1,0 +1,180 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock
+
+from wazo_chatd.database.models import UserIdentity
+from wazo_chatd.database.queries.user_identity import UserIdentityDAO
+from wazo_chatd.exceptions import UnknownUserIdentityException
+from wazo_chatd.plugins.connectors.services import ConnectorService
+
+TENANT_A = 'tenant-a-uuid'
+USER_UUID = 'user-uuid'
+IDENTITY_UUID = 'identity-uuid'
+
+
+def _make_identity(
+    identity_uuid: str = IDENTITY_UUID,
+    user_uuid: str = USER_UUID,
+    tenant_uuid: str = TENANT_A,
+    backend: str = 'twilio',
+    identity: str = '+15551234',
+) -> UserIdentity:
+    obj = UserIdentity(
+        user_uuid=user_uuid,
+        tenant_uuid=tenant_uuid,
+        backend=backend,
+        identity=identity,
+    )
+    obj.uuid = identity_uuid  # type: ignore[assignment]
+    return obj
+
+
+def _mock_execute(*results: UserIdentity) -> Mock:
+    scalars = Mock()
+    scalars.all.return_value = list(results)
+    scalars.first.return_value = results[0] if results else None
+
+    execute_result = Mock()
+    execute_result.scalars.return_value = scalars
+    return execute_result
+
+
+def _make_dao(execute_result: Mock) -> UserIdentityDAO:
+    session = Mock()
+    session.execute.return_value = execute_result
+    return UserIdentityDAO(lambda: session)
+
+
+class TestUserIdentityDAOCreate(unittest.TestCase):
+    def test_create_adds_and_flushes(self) -> None:
+        dao = _make_dao(_mock_execute())
+        identity = _make_identity()
+
+        result = dao.create(identity)
+
+        assert result is identity
+        dao.session.add.assert_called_once_with(identity)
+        dao.session.flush.assert_called_once()
+
+
+class TestUserIdentityDAOListByUser(unittest.TestCase):
+    def test_returns_identities(self) -> None:
+        identity = _make_identity()
+        dao = _make_dao(_mock_execute(identity))
+
+        result = dao.list_by_user(USER_UUID, tenant_uuids=[TENANT_A])
+
+        assert result == [identity]
+
+    def test_returns_empty_when_no_match(self) -> None:
+        dao = _make_dao(_mock_execute())
+
+        result = dao.list_by_user(USER_UUID, tenant_uuids=[TENANT_A])
+
+        assert result == []
+
+
+class TestUserIdentityDAOGet(unittest.TestCase):
+    def test_get_returns_identity(self) -> None:
+        identity = _make_identity()
+        dao = _make_dao(_mock_execute(identity))
+
+        result = dao.get([TENANT_A], IDENTITY_UUID, user_uuid=USER_UUID)
+
+        assert result is identity
+
+    def test_get_raises_when_not_found(self) -> None:
+        dao = _make_dao(_mock_execute())
+
+        with self.assertRaises(UnknownUserIdentityException):
+            dao.get([TENANT_A], 'nonexistent')
+
+    def test_get_without_user_uuid(self) -> None:
+        identity = _make_identity()
+        dao = _make_dao(_mock_execute(identity))
+
+        result = dao.get([TENANT_A], IDENTITY_UUID)
+
+        assert result is identity
+
+
+class TestUserIdentityDAOUpdate(unittest.TestCase):
+    def test_update_flushes(self) -> None:
+        dao = _make_dao(_mock_execute())
+        identity = _make_identity()
+
+        dao.update(identity)
+
+        dao.session.flush.assert_called_once()
+
+
+class TestUserIdentityDAODelete(unittest.TestCase):
+    def test_delete_removes_and_flushes(self) -> None:
+        dao = _make_dao(_mock_execute())
+        identity = _make_identity()
+
+        dao.delete(identity)
+
+        dao.session.delete.assert_called_once_with(identity)
+        dao.session.flush.assert_called_once()
+
+
+class TestConnectorServiceIdentityCRUD(unittest.TestCase):
+    def _build_service(self) -> ConnectorService:
+        from wazo_chatd.plugins.connectors.registry import ConnectorRegistry
+
+        dao = Mock()
+        registry = ConnectorRegistry()
+        return ConnectorService(dao, registry, Mock())
+
+    def test_list_identities(self) -> None:
+        service = self._build_service()
+        identity = _make_identity()
+        service._dao.user_identity.list_by_user.return_value = [identity]
+
+        result = service.list_identities([TENANT_A], USER_UUID)
+
+        assert result == [identity]
+        service._dao.user_identity.list_by_user.assert_called_once_with(
+            USER_UUID, tenant_uuids=[TENANT_A]
+        )
+
+    def test_get_identity(self) -> None:
+        service = self._build_service()
+        identity = _make_identity()
+        service._dao.user_identity.get.return_value = identity
+
+        result = service.get_identity([TENANT_A], IDENTITY_UUID, user_uuid=USER_UUID)
+
+        assert result is identity
+
+    def test_create_identity(self) -> None:
+        service = self._build_service()
+        identity = _make_identity()
+        service._dao.user_identity.create.return_value = identity
+
+        result = service.create_identity(identity)
+
+        assert result is identity
+        service._dao.user_identity.create.assert_called_once_with(identity)
+
+    def test_update_identity(self) -> None:
+        service = self._build_service()
+        identity = _make_identity()
+
+        result = service.update_identity(identity)
+
+        assert result is identity
+        service._dao.user_identity.update.assert_called_once_with(identity)
+
+    def test_delete_identity(self) -> None:
+        service = self._build_service()
+        identity = _make_identity()
+
+        service.delete_identity(identity)
+
+        service._dao.user_identity.delete.assert_called_once_with(identity)


### PR DESCRIPTION
## Summary
- Add test connector backend (`TestConnector`) with configurable mock server
- Add Docker infrastructure: `Dockerfile-chatd-connectors`, `Dockerfile-connector-mock`, compose override
- Add `ConnectorIntegrationTest` base class with auth external config setup
- Add `ConnectorMockClient` helper for controlling test connector behavior

### Test coverage (~55 integration tests):
- **Identity CRUD**: list, get, create, update, delete + auth + tenant isolation
- **Validation**: room reachability, message identity requirements
- **Delivery**: outbound send, failed delivery, status updates (delivered, failed, transient)
- **Inbound**: webhook dispatch, backend hints, idempotency dedup, echo dedup
- **Bus events**: message_created with nested delivery, delivery_status
- **Visibility**: sender sees pending, other user doesn't, visible after delivered, internal visible to all
- **Multi-channel**: full flow with internal + outbound + inbound in same room

## Test plan
- [ ] `cd integration_tests && python -m pytest suite/test_connector_delivery.py suite/test_connector_validation.py suite/test_connector_user_identity.py suite/test_connector_bus_events.py suite/test_room_identities.py -v`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily test-only and Docker scaffolding, but it adds new images/compose wiring and modifies integration test bootstrapping, which can impact CI stability and test runtime.
> 
> **Overview**
> Adds a new **connectors** integration-test asset that runs `chatd` with an installable `TestConnector` plugin plus a Flask-based `connector-mock` service to control send behavior and capture outbound messages.
> 
> Extends the integration test harness (`conftest.py`, `helpers/base.py`) with `ConnectorIntegrationTest`/`ConnectorAssetLaunchingTestCase`, external config injection for the test backend, and a `ConnectorMockClient` helper.
> 
> Introduces a large set of new integration tests validating connector flows end-to-end: inbound webhook handling (including backend hint/idempotency), outbound delivery + status updates, bus events, room/message validation rules, identity CRUD/auth/tenant isolation, visibility rules, and DB-level `MessageMeta`/`DeliveryRecord` behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4795b73035ca0a37520a145eff41b33ec61d4d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->