### PR TITLE
[ITEM-101] Update API specs and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 26.05
+
+* New endpoints:
+  * `GET /1.0/users/{user_uuid}/identities`
+  * `POST /1.0/users/{user_uuid}/identities`
+  * `GET /1.0/users/{user_uuid}/identities/{identity_uuid}`
+  * `PUT /1.0/users/{user_uuid}/identities/{identity_uuid}`
+  * `DELETE /1.0/users/{user_uuid}/identities/{identity_uuid}`
+  * `GET /1.0/users/me/rooms/{room_uuid}/identities`
+  * `POST /1.0/connectors/incoming`
+  * `POST /1.0/connectors/incoming/{backend}`
+
+* New read only parameters have been added to the room user resource:
+  * `identity`
+
+* New parameters have been added to the message creation endpoint:
+  * `sender_identity_uuid`
+
+* New read only parameters have been added to the message resource:
+  * `type`
+  * `backend`
+
+* `POST /1.0/users/me/rooms` may now return `409` when a participant is unreachable
+
+* `POST /1.0/users/me/rooms/{room_uuid}/messages` may now return:
+  * `202` when outbound delivery is accepted
+  * `409` when `sender_identity_uuid` is required but missing
+
+* New configuration: `enabled_connectors` to control which connector backends are loaded
+
 ## 26.02
 
 * `POST`, `PATCH` and `PUT` request bodies to endpoints accepting JSON payload are systematically parsed as JSON, with or without a proper `Content-Type` header;

--- a/wazo_chatd/plugins/connectors/api.yml
+++ b/wazo_chatd/plugins/connectors/api.yml
@@ -1,0 +1,210 @@
+paths:
+  /users/{user_uuid}/identities:
+    get:
+      operationId: list_user_identities
+      summary: List user identities
+      description: '**Required ACL:** `chatd.users.{user_uuid}.identities.read`'
+      tags:
+      - identities
+      parameters:
+      - $ref: '#/parameters/tenant_uuid'
+      - $ref: '#/parameters/user_uuid'
+      responses:
+        '200':
+          description: Identity list
+          schema:
+            $ref: '#/definitions/UserIdentityList'
+    post:
+      operationId: create_user_identity
+      summary: Create user identity
+      description: '**Required ACL:** `chatd.users.{user_uuid}.identities.create`'
+      tags:
+      - identities
+      parameters:
+      - $ref: '#/parameters/tenant_uuid'
+      - $ref: '#/parameters/user_uuid'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/UserIdentityRequest'
+      responses:
+        '201':
+          description: Identity created
+          schema:
+            $ref: '#/definitions/UserIdentity'
+        '400':
+          $ref: '#/responses/InvalidRequest'
+  /users/{user_uuid}/identities/{identity_uuid}:
+    get:
+      operationId: get_user_identity
+      summary: Get user identity
+      description: '**Required ACL:** `chatd.users.{user_uuid}.identities.{identity_uuid}.read`'
+      tags:
+      - identities
+      parameters:
+      - $ref: '#/parameters/tenant_uuid'
+      - $ref: '#/parameters/user_uuid'
+      - $ref: '#/parameters/identity_uuid'
+      responses:
+        '200':
+          description: Identity
+          schema:
+            $ref: '#/definitions/UserIdentity'
+        '404':
+          $ref: '#/responses/NotFoundError'
+    put:
+      operationId: update_user_identity
+      summary: Update user identity
+      description: '**Required ACL:** `chatd.users.{user_uuid}.identities.{identity_uuid}.update`'
+      tags:
+      - identities
+      parameters:
+      - $ref: '#/parameters/tenant_uuid'
+      - $ref: '#/parameters/user_uuid'
+      - $ref: '#/parameters/identity_uuid'
+      - name: body
+        in: body
+        required: true
+        schema:
+          $ref: '#/definitions/UserIdentityRequest'
+      responses:
+        '204':
+          $ref: '#/responses/ResourceUpdated'
+        '400':
+          $ref: '#/responses/InvalidRequest'
+        '404':
+          $ref: '#/responses/NotFoundError'
+    delete:
+      operationId: delete_user_identity
+      summary: Delete user identity
+      description: '**Required ACL:** `chatd.users.{user_uuid}.identities.{identity_uuid}.delete`'
+      tags:
+      - identities
+      parameters:
+      - $ref: '#/parameters/tenant_uuid'
+      - $ref: '#/parameters/user_uuid'
+      - $ref: '#/parameters/identity_uuid'
+      responses:
+        '204':
+          $ref: '#/responses/ResourceUpdated'
+        '404':
+          $ref: '#/responses/NotFoundError'
+  /users/me/rooms/{room_uuid}/identities:
+    get:
+      operationId: list_room_identities
+      summary: List usable identities for a room
+      description: '**Required ACL:** `chatd.users.me.rooms.{room_uuid}.identities.read`'
+      tags:
+      - identities
+      - rooms
+      parameters:
+      - $ref: '#/parameters/room_uuid'
+      responses:
+        '200':
+          description: Identity list
+          schema:
+            $ref: '#/definitions/UserIdentityList'
+        '404':
+          $ref: '#/responses/NotFoundError'
+  /connectors/incoming:
+    post:
+      operationId: connector_webhook
+      summary: Receive incoming webhook from connector
+      description: Dispatches an incoming webhook to the matching connector backend.
+      tags:
+      - connectors
+      parameters:
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+      responses:
+        '204':
+          description: Webhook accepted
+        '404':
+          description: No connector matched the webhook
+  /connectors/incoming/{backend}:
+    post:
+      operationId: connector_webhook_with_hint
+      summary: Receive incoming webhook with backend hint
+      description: Dispatches an incoming webhook, trying the specified backend first.
+      tags:
+      - connectors
+      parameters:
+      - name: backend
+        in: path
+        type: string
+        description: Backend name hint for faster dispatch
+        required: true
+      - name: body
+        in: body
+        required: true
+        schema:
+          type: object
+      responses:
+        '204':
+          description: Webhook accepted
+        '404':
+          description: No connector matched the webhook
+
+parameters:
+  identity_uuid:
+    name: identity_uuid
+    in: path
+    type: string
+    description: The UUID of the identity
+    required: true
+
+definitions:
+  UserIdentityList:
+    title: UserIdentityList
+    properties:
+      items:
+        type: array
+        items:
+          $ref: '#/definitions/UserIdentity'
+      total:
+        type: integer
+        description: The number of results
+
+  UserIdentity:
+    title: UserIdentity
+    properties:
+      uuid:
+        type: string
+        description: The UUID of the identity
+        readOnly: true
+      backend:
+        type: string
+        description: The connector backend name
+      type:
+        type: string
+        description: The messaging type
+      identity:
+        type: string
+        description: The external identity value
+      extra:
+        type: object
+        description: Additional metadata
+
+  UserIdentityRequest:
+    title: UserIdentityRequest
+    properties:
+      backend:
+        type: string
+        description: The connector backend name
+      type:
+        type: string
+        description: The messaging type
+      identity:
+        type: string
+        description: The external identity value
+      extra:
+        type: object
+        description: Additional metadata
+    required:
+      - backend
+      - type
+      - identity

--- a/wazo_chatd/plugins/rooms/api.yml
+++ b/wazo_chatd/plugins/rooms/api.yml
@@ -27,6 +27,8 @@ paths:
             $ref: '#/definitions/Room'
         '400':
           $ref: '#/responses/InvalidRequest'
+        '409':
+          description: A participant is unreachable via any registered connector
     get:
       operationId: get_room
       summary: Get room
@@ -82,13 +84,19 @@ paths:
           $ref: '#/definitions/UserMessagePOST'
       responses:
         '201':
-          description: Message created
+          description: Message created (no outbound delivery)
+          schema:
+            $ref: '#/definitions/Message'
+        '202':
+          description: Message created, outbound delivery accepted
           schema:
             $ref: '#/definitions/Message'
         '400':
           $ref: '#/responses/InvalidRequest'
         '404':
           $ref: '#/responses/NotFoundError'
+        '409':
+          description: sender_identity_uuid is required but missing, or identity is not reachable
     get:
       operationId: list_room_message
       summary: List room messages
@@ -164,6 +172,10 @@ definitions:
       wazo_uuid:
         type: string
         description: The wazo of the tenant_uuid. Default to the same wazo as the token owner
+      identity:
+        type: string
+        description: The external identity of this participant (e.g. a phone number for SMS).
+          When set, the participant is reachable via the matching connector backend.
     required:
       - uuid
 
@@ -187,9 +199,13 @@ definitions:
       alias:
         type: string
         description: Alias/nickname of the sender
+      sender_identity_uuid:
+        type: string
+        format: uuid
+        description: The UUID of the sender's identity to use for outbound delivery.
+          Required when the room contains external participants.
     required:
       - content
-      - alias
 
   Message:
     properties:
@@ -203,6 +219,14 @@ definitions:
       alias:
         type: string
         description: Alias/nickname of the sender
+      type:
+        type: string
+        description: The messaging type (e.g. 'internal', 'sms')
+        readOnly: true
+      backend:
+        type: string
+        description: The connector backend name (e.g. 'twilio'). Null for internal messages.
+        readOnly: true
       user_uuid:
         type: string
         description: user uuid of the sender


### PR DESCRIPTION
## Summary
- Add `wazo_chatd/plugins/connectors/api.yml` — OpenAPI spec for identity CRUD, room identities, webhooks
- Update `wazo_chatd/plugins/rooms/api.yml` — nested delivery object, sender_identity_uuid, identity on RoomUser, 202/409 responses
- Update `CHANGELOG.md` — 26.05 section with all new endpoints and fields

## Test plan
- [ ] `python -m pytest integration_tests/suite/test_documentation.py -v` (validates OpenAPI spec)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only changes (OpenAPI + changelog) with no runtime code modifications, but they define new endpoints/fields and new `202/409` behaviors that client implementations may need to handle.
> 
> **Overview**
> Documents new connector capabilities by adding a `connectors` OpenAPI spec covering **user identity CRUD**, **room-usable identities**, and **incoming connector webhook** dispatch endpoints.
> 
> Updates the `rooms` API spec to reflect connector-aware messaging: adds `RoomUser.identity`, adds `sender_identity_uuid` on message creation, exposes `Message.type`/`Message.backend`, and documents new `202` (accepted for outbound delivery) and `409` (unreachable/missing sender identity) responses, plus a `409` on room creation when a participant is unreachable.
> 
> Adds a `26.05` changelog entry summarizing these new endpoints, fields, status codes, and the new `enabled_connectors` configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525f93b0a0326c78b7fbff5379cf0fd6658f0484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->