### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - 9486
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - '5672'
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a single integration-test Docker image tag change with no production code impact, though it could surface version-specific broker behavior in tests.
> 
> **Overview**
> Pins the integration test `docker-compose.yml` RabbitMQ service from the floating `rabbitmq` image tag to `rabbitmq:3` to make test environments more deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8d593f1f111311168dd9f9440b71865de55c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->