### PR TITLE
integration tests: tear down asset containers at marker-group boundaries

### DIFF
--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -1,9 +1,17 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+from collections.abc import Callable
+
 import pytest
+from wazo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
 
 from .helpers import base as asset
+
+logger = logging.getLogger(__name__)
+
+_teardowns: dict[str, Callable[[], None]] = {}
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -15,40 +23,72 @@ def pytest_collection_modifyitems(session, config, items):
     items.sort(key=lambda item: item.parent.own_markers[0].args[0])
 
 
+def _marker_of(item) -> str | None:
+    if not item.parent.own_markers:
+        return None
+    return item.parent.own_markers[0].args[0]
+
+
+def _setup(marker: str, asset_class: type[AssetLaunchingTestCase]) -> None:
+    asset_class.setUpClass()
+    _teardowns[marker] = asset_class.tearDownClass
+
+
+def _teardown(marker: str) -> None:
+    teardown = _teardowns.pop(marker, None)
+    if teardown is None:
+        return
+    try:
+        teardown()
+    except Exception:
+        logger.exception('Failed to tear down asset for marker %r', marker)
+
+
+def pytest_runtest_teardown(item, nextitem) -> None:
+    # Eagerly tear down the active asset at marker-group boundaries; the
+    # session-scoped fixture's finally still handles the very last asset.
+    if nextitem is None:
+        return
+    current = _marker_of(item)
+    upcoming = _marker_of(nextitem)
+    if current is not None and current != upcoming:
+        _teardown(current)
+
+
 @pytest.fixture(scope='session')
 def base():
-    asset.APIAssetLaunchingTestCase.setUpClass()
+    _setup('base', asset.APIAssetLaunchingTestCase)
     try:
         yield
     finally:
-        asset.APIAssetLaunchingTestCase.tearDownClass()
+        _teardown('base')
 
 
 @pytest.fixture(scope='session')
 def initialization():
-    asset.InitAssetLaunchingTestCase.setUpClass()
+    _setup('initialization', asset.InitAssetLaunchingTestCase)
     try:
         yield
     finally:
-        asset.InitAssetLaunchingTestCase.tearDownClass()
+        _teardown('initialization')
 
 
 @pytest.fixture(scope='session')
 def database():
-    asset.DBAssetLaunchingTestCase.setUpClass()
+    _setup('database', asset.DBAssetLaunchingTestCase)
     try:
         yield
     finally:
-        asset.DBAssetLaunchingTestCase.tearDownClass()
+        _teardown('database')
 
 
 @pytest.fixture(scope='session')
 def teams():
-    asset.TeamsAssetLaunchingTestCase.setUpClass()
+    _setup('teams', asset.TeamsAssetLaunchingTestCase)
     try:
         yield
     finally:
-        asset.TeamsAssetLaunchingTestCase.tearDownClass()
+        _teardown('teams')
 
 
 @pytest.fixture(autouse=True, scope='function')

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -12,6 +12,7 @@ from .helpers import base as asset
 logger = logging.getLogger(__name__)
 
 _teardowns: dict[str, Callable[[], None]] = {}
+_teardown_failures: list[tuple[str, BaseException]] = []
 
 
 def pytest_collection_modifyitems(session, config, items):
@@ -53,8 +54,16 @@ def pytest_runtest_teardown(item, nextitem) -> None:
     if current is not None and current != upcoming:
         try:
             _teardown(current)
-        except Exception:
+        except Exception as exc:
             logger.exception('Failed to tear down asset for marker %r', current)
+            _teardown_failures.append((current, exc))
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config) -> None:
+    for marker, exc in _teardown_failures:
+        terminalreporter.write_sep(
+            '!', f'Asset teardown failed for marker {marker!r}: {exc}'
+        )
 
 
 @pytest.fixture(scope='session')

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -35,25 +35,26 @@ def _setup(marker: str, asset_class: type[AssetLaunchingTestCase]) -> None:
 
 
 def _teardown(marker: str) -> None:
-    teardown = _teardowns.pop(marker, None)
-    if teardown is None:
-        return
-    try:
+    if teardown := _teardowns.pop(marker, None):
         teardown()
-    except Exception:
-        logger.exception('Failed to tear down asset for marker %r', marker)
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_runtest_teardown(item, nextitem) -> None:
     # Eagerly tear down the active asset at marker-group boundaries; the
     # session-scoped fixture's finally still handles the very last asset.
+    # Swallow errors here so a teardown failure can't abort the next test's
+    # setup; the fixture-finally path lets exceptions propagate so they
+    # surface in pytest's error summary.
     if nextitem is None:
         return
     current = _marker_of(item)
     upcoming = _marker_of(nextitem)
     if current is not None and current != upcoming:
-        _teardown(current)
+        try:
+            _teardown(current)
+        except Exception:
+            logger.exception('Failed to tear down asset for marker %r', current)
 
 
 @pytest.fixture(scope='session')

--- a/integration_tests/suite/conftest.py
+++ b/integration_tests/suite/conftest.py
@@ -44,6 +44,7 @@ def _teardown(marker: str) -> None:
         logger.exception('Failed to tear down asset for marker %r', marker)
 
 
+@pytest.hookimpl(trylast=True)
 def pytest_runtest_teardown(item, nextitem) -> None:
     # Eagerly tear down the active asset at marker-group boundaries; the
     # session-scoped fixture's finally still handles the very last asset.


### PR DESCRIPTION
## Summary
- Session-scoped fixtures (`base`/`initialization`/`database`/`teams`) only ran their teardown at session end, so containers from earlier asset groups stayed alive concurrently with the next group's containers (e.g. running `test_config.py` then `test_db_channel.py` left 4 `chatd_base-*` containers running alongside `postgres_database-*`).
- Each fixture now self-registers its teardown into a shared map keyed by marker name. A new `pytest_runtest_teardown(item, nextitem)` hook detects a marker change and eagerly tears down the asset about to leave. The fixture's `finally` still handles the very last asset; idempotency comes from `dict.pop` returning `None` on the second call.
- No file moves, no static marker→class registry — fixtures remain the single source of truth for the lifecycle.

## Test plan
- [x] `pytest integration_tests/suite/test_config.py integration_tests/suite/test_db_channel.py` — observe `docker ps` while running; the 4 `chatd_base-*` containers should be killed *before* `chatd_database-*` start.
- [x] Run the full integration suite and confirm no regression in setup/teardown errors.
- [x] After session end, confirm no asset containers are left running (only `Exited` records remain, as before).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pytest hook/fixture lifecycle, so mistakes could leak containers or cause flaky setup/teardown ordering issues, but the change is localized to the integration test harness.
> 
> **Overview**
> Integration test assets are now torn down *between* marker groups instead of only at session end, preventing containers from prior groups from running concurrently with the next group.
> 
> `conftest.py` adds a shared teardown registry plus a `pytest_runtest_teardown` hook that detects marker changes and eagerly runs the prior group’s teardown; failures are logged, collected, and surfaced in `pytest_terminal_summary`, while session fixtures still perform a final (idempotent) teardown in `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06e58b92037e188cdbe0368d76ad07a481776875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->