### PR TITLE
connector poller: adaptive cadence + herd protection

### DIFF
--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -78,7 +78,6 @@ _DEFAULT_CONFIG = {
         'provider_cache_ttl': 300,
         'poll_interval_min': 5,
         'poll_interval_max': 60,
-        'poll_interval_default': 30,
     },
     'initialization': {
         'enabled': True,

--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -78,6 +78,11 @@ _DEFAULT_CONFIG = {
         'provider_cache_ttl': 300,
         'poll_interval_min': 5,
         'poll_interval_max': 60,
+        'poll_tau_speedup': 5,
+        'poll_tau_slowdown': 60,
+        'poll_jitter_ratio': 0.1,
+        'poll_rate_limit_floor': 30,
+        'poll_rate_limit_window': 300,
     },
     'initialization': {
         'enabled': True,

--- a/wazo_chatd/plugins/connectors/cadence.py
+++ b/wazo_chatd/plugins/connectors/cadence.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -15,20 +17,32 @@ class CadenceController:
     poll_max: float
     tau_speedup: float = 5.0
     tau_slowdown: float = 60.0
+    rate_limit_floor: float = 30.0
     interval: float = 0.0
+    rate_limit_until: float = 0.0
+    clock: Callable[[], float] = field(default=time.monotonic)
 
     def __post_init__(self) -> None:
         self.interval = self.poll_min
 
+    def effective_min(self) -> float:
+        if self.clock() < self.rate_limit_until:
+            return max(self.poll_min, self.rate_limit_floor)
+        return self.poll_min
+
+    def penalize(self, *, duration: float) -> None:
+        self.rate_limit_until = self.clock() + duration
+
     def step(self, *, yielded: bool, dt: float) -> None:
-        target = self.poll_min if yielded else self.poll_max
+        eff_min = self.effective_min()
+        target = eff_min if yielded else self.poll_max
         tau = self.tau_speedup if yielded else self.tau_slowdown
         rate = min(dt / tau, 1.0) if tau > 0 else 1.0
         self.interval += rate * (target - self.interval)
-        self.interval = max(self.poll_min, min(self.poll_max, self.interval))
+        self.interval = max(eff_min, min(self.poll_max, self.interval))
 
     def next_interval(self) -> float:
-        return self.interval
+        return max(self.effective_min(), min(self.poll_max, self.interval))
 
 
 def apply_jitter(

--- a/wazo_chatd/plugins/connectors/cadence.py
+++ b/wazo_chatd/plugins/connectors/cadence.py
@@ -1,0 +1,30 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class CadenceController:
+    """Forward-Euler cadence controller for connector pollers."""
+
+    poll_min: float
+    poll_max: float
+    tau_speedup: float = 5.0
+    tau_slowdown: float = 60.0
+    interval: float = 0.0
+
+    def __post_init__(self) -> None:
+        self.interval = self.poll_min
+
+    def step(self, *, yielded: bool, dt: float) -> None:
+        target = self.poll_min if yielded else self.poll_max
+        tau = self.tau_speedup if yielded else self.tau_slowdown
+        rate = min(dt / tau, 1.0) if tau > 0 else 1.0
+        self.interval += rate * (target - self.interval)
+        self.interval = max(self.poll_min, min(self.poll_max, self.interval))
+
+    def next_interval(self) -> float:
+        return self.interval

--- a/wazo_chatd/plugins/connectors/cadence.py
+++ b/wazo_chatd/plugins/connectors/cadence.py
@@ -18,9 +18,9 @@ class PollerCadence:
     tau_speedup: float = 5.0
     tau_slowdown: float = 60.0
     rate_limit_floor: float = 30.0
-    interval: float = 0.0
-    rate_limit_until: float = 0.0
     clock: Callable[[], float] = field(default=time.monotonic)
+    interval: float = field(init=False, default=0.0)
+    rate_limit_until: float = field(init=False, default=0.0)
     _last_step_time: float = field(init=False, default=0.0)
 
     def __post_init__(self) -> None:
@@ -34,6 +34,9 @@ class PollerCadence:
 
     def penalize(self, *, duration: float) -> None:
         self.rate_limit_until = self.clock() + duration
+
+    def reset_step_clock(self) -> None:
+        self._last_step_time = self.clock()
 
     def step(self, *, did_work: bool) -> None:
         now = self.clock()
@@ -56,7 +59,7 @@ def apply_jitter(
     ratio: float = 0.1,
     rng: random.Random | None = None,
 ) -> float:
-    if ratio <= 0:
+    if not 0 < ratio < 1:
         return value
 
     sample = rng.uniform(-ratio, ratio) if rng else random.uniform(-ratio, ratio)

--- a/wazo_chatd/plugins/connectors/cadence.py
+++ b/wazo_chatd/plugins/connectors/cadence.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass, field
 
 
 @dataclass
-class CadenceController:
-    """Forward-Euler cadence controller for connector pollers."""
+class PollerCadence:
+    """Forward-Euler cadence for connector pollers."""
 
     poll_min: float
     poll_max: float
@@ -21,9 +21,11 @@ class CadenceController:
     interval: float = 0.0
     rate_limit_until: float = 0.0
     clock: Callable[[], float] = field(default=time.monotonic)
+    _last_step_time: float = field(init=False, default=0.0)
 
     def __post_init__(self) -> None:
         self.interval = self.poll_min
+        self._last_step_time = self.clock()
 
     def effective_min(self) -> float:
         if self.clock() < self.rate_limit_until:
@@ -33,10 +35,13 @@ class CadenceController:
     def penalize(self, *, duration: float) -> None:
         self.rate_limit_until = self.clock() + duration
 
-    def step(self, *, yielded: bool, dt: float) -> None:
+    def step(self, *, did_work: bool) -> None:
+        now = self.clock()
+        dt = now - self._last_step_time
+        self._last_step_time = now
         eff_min = self.effective_min()
-        target = eff_min if yielded else self.poll_max
-        tau = self.tau_speedup if yielded else self.tau_slowdown
+        target = eff_min if did_work else self.poll_max
+        tau = self.tau_speedup if did_work else self.tau_slowdown
         rate = min(dt / tau, 1.0) if tau > 0 else 1.0
         self.interval += rate * (target - self.interval)
         self.interval = max(eff_min, min(self.poll_max, self.interval))
@@ -53,5 +58,6 @@ def apply_jitter(
 ) -> float:
     if ratio <= 0:
         return value
+
     sample = rng.uniform(-ratio, ratio) if rng else random.uniform(-ratio, ratio)
     return value * (1.0 + sample)

--- a/wazo_chatd/plugins/connectors/cadence.py
+++ b/wazo_chatd/plugins/connectors/cadence.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass
 
 
@@ -28,3 +29,15 @@ class CadenceController:
 
     def next_interval(self) -> float:
         return self.interval
+
+
+def apply_jitter(
+    value: float,
+    *,
+    ratio: float = 0.1,
+    rng: random.Random | None = None,
+) -> float:
+    if ratio <= 0:
+        return value
+    sample = rng.uniform(-ratio, ratio) if rng else random.uniform(-ratio, ratio)
+    return value * (1.0 + sample)

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -26,7 +26,7 @@ from wazo_chatd.database.async_helpers import (
 )
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict
 from wazo_chatd.plugin_helpers.queue import AsyncQueue, QueueFull
-from wazo_chatd.plugins.connectors.cadence import CadenceController
+from wazo_chatd.plugins.connectors.cadence import CadenceController, apply_jitter
 from wazo_chatd.plugins.connectors.connector import Connector
 from wazo_chatd.plugins.connectors.exceptions import ConnectorRateLimited
 from wazo_chatd.plugins.connectors.executor import MAX_RETRY_AFTER, DeliveryExecutor
@@ -269,6 +269,7 @@ class DeliveryRunner(Runner):
         self._poll_default = float(config['delivery'].get('poll_interval_default', 30))
         self._tau_speedup = float(config['delivery'].get('poll_tau_speedup', 5))
         self._tau_slowdown = float(config['delivery'].get('poll_tau_slowdown', 60))
+        self._jitter_ratio = float(config['delivery'].get('poll_jitter_ratio', 0.1))
 
         self._db_uri = str(config.get('db_uri', ''))
         engine, session_factory = init_async_db(self._db_uri)
@@ -670,7 +671,9 @@ class DeliveryRunner(Runner):
             except Exception:
                 logger.exception('Poller for %s hit unexpected error, continuing', key)
                 controller.step(yielded=False, dt=prev_dt)
-            sleep_for = controller.next_interval()
+            sleep_for = apply_jitter(
+                controller.next_interval(), ratio=self._jitter_ratio
+            )
             await asyncio.sleep(sleep_for)
             prev_dt = sleep_for
 

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -641,7 +641,7 @@ class DeliveryRunner(Runner):
 
     async def _run_poller(self, key: CacheKey, instance: Connector) -> None:
         tenant_uuid, backend = key
-        interval = self._poll_default
+        interval = self._poll_min
         while True:
             try:
                 yielded = await self._scan_inbound(instance, key)

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -652,8 +652,7 @@ class DeliveryRunner(Runner):
 
     async def _run_poller(self, key: CacheKey, instance: Connector) -> None:
         tenant_uuid, backend = key
-        if self._jitter_ratio > 0:
-            await asyncio.sleep(random.uniform(0, self._poll_min))
+        await asyncio.sleep(random.uniform(0, self._poll_min))
 
         cadence = PollerCadence(
             poll_min=self._poll_min,
@@ -679,9 +678,15 @@ class DeliveryRunner(Runner):
                 )
                 cadence.penalize(duration=self._rate_limit_window)
                 await asyncio.sleep(sleep_for)
+                cadence.reset_step_clock()
                 continue
             except Exception:
-                logger.exception('Poller for %s hit unexpected error, continuing', key)
+                logger.exception(
+                    'Poller for %s hit unexpected error, throttling for %ds',
+                    key,
+                    self._rate_limit_window,
+                )
+                cadence.penalize(duration=self._rate_limit_window)
                 cadence.step(did_work=False)
 
             sleep_for = apply_jitter(cadence.next_interval(), ratio=self._jitter_ratio)

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -271,6 +271,12 @@ class DeliveryRunner(Runner):
         self._tau_speedup = float(config['delivery'].get('poll_tau_speedup', 5))
         self._tau_slowdown = float(config['delivery'].get('poll_tau_slowdown', 60))
         self._jitter_ratio = float(config['delivery'].get('poll_jitter_ratio', 0.1))
+        self._rate_limit_floor = float(
+            config['delivery'].get('poll_rate_limit_floor', 30)
+        )
+        self._rate_limit_window = float(
+            config['delivery'].get('poll_rate_limit_window', 300)
+        )
 
         self._db_uri = str(config.get('db_uri', ''))
         engine, session_factory = init_async_db(self._db_uri)
@@ -653,6 +659,7 @@ class DeliveryRunner(Runner):
             poll_max=self._poll_max,
             tau_speedup=self._tau_speedup,
             tau_slowdown=self._tau_slowdown,
+            rate_limit_floor=self._rate_limit_floor,
         )
         prev_dt = self._poll_min
         while True:
@@ -668,6 +675,7 @@ class DeliveryRunner(Runner):
                 logger.info(
                     'Poller for %s rate-limited, sleeping %.1fs', key, sleep_for
                 )
+                controller.penalize(duration=self._rate_limit_window)
                 await asyncio.sleep(sleep_for)
                 prev_dt = sleep_for
                 continue

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -12,6 +12,7 @@ import logging
 import random
 import threading
 from collections.abc import Callable, Coroutine, Iterable
+from time import monotonic
 from types import TracebackType
 from typing import Any, ClassVar
 
@@ -27,7 +28,7 @@ from wazo_chatd.database.async_helpers import (
 )
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict
 from wazo_chatd.plugin_helpers.queue import AsyncQueue, QueueFull
-from wazo_chatd.plugins.connectors.cadence import CadenceController, apply_jitter
+from wazo_chatd.plugins.connectors.cadence import PollerCadence, apply_jitter
 from wazo_chatd.plugins.connectors.connector import Connector
 from wazo_chatd.plugins.connectors.exceptions import ConnectorRateLimited
 from wazo_chatd.plugins.connectors.executor import MAX_RETRY_AFTER, DeliveryExecutor
@@ -654,19 +655,21 @@ class DeliveryRunner(Runner):
         tenant_uuid, backend = key
         if self._jitter_ratio > 0:
             await asyncio.sleep(random.uniform(0, self._poll_min))
-        controller = CadenceController(
+
+        cadence = PollerCadence(
             poll_min=self._poll_min,
             poll_max=self._poll_max,
             tau_speedup=self._tau_speedup,
             tau_slowdown=self._tau_slowdown,
             rate_limit_floor=self._rate_limit_floor,
+            clock=monotonic,
         )
-        prev_dt = self._poll_min
+
         while True:
             try:
-                yielded = await self._scan_inbound(instance, key)
-                yielded |= await self._track_outbound(instance, tenant_uuid, backend)
-                controller.step(yielded=yielded, dt=prev_dt)
+                did_work = await self._scan_inbound(instance, key)
+                did_work |= await self._track_outbound(instance, tenant_uuid, backend)
+                cadence.step(did_work=did_work)
             except asyncio.CancelledError:
                 logger.info('Poller for %s cancelled', key)
                 raise
@@ -675,18 +678,15 @@ class DeliveryRunner(Runner):
                 logger.info(
                     'Poller for %s rate-limited, sleeping %.1fs', key, sleep_for
                 )
-                controller.penalize(duration=self._rate_limit_window)
+                cadence.penalize(duration=self._rate_limit_window)
                 await asyncio.sleep(sleep_for)
-                prev_dt = sleep_for
                 continue
             except Exception:
                 logger.exception('Poller for %s hit unexpected error, continuing', key)
-                controller.step(yielded=False, dt=prev_dt)
-            sleep_for = apply_jitter(
-                controller.next_interval(), ratio=self._jitter_ratio
-            )
+                cadence.step(did_work=False)
+
+            sleep_for = apply_jitter(cadence.next_interval(), ratio=self._jitter_ratio)
             await asyncio.sleep(sleep_for)
-            prev_dt = sleep_for
 
     async def _scan_inbound(self, instance: Connector, key: CacheKey) -> bool:
         try:

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -268,7 +268,6 @@ class DeliveryRunner(Runner):
         self._max_tasks = int(config['delivery']['max_concurrent_tasks'])
         self._poll_min = float(config['delivery'].get('poll_interval_min', 5))
         self._poll_max = float(config['delivery'].get('poll_interval_max', 60))
-        self._poll_default = float(config['delivery'].get('poll_interval_default', 30))
         self._tau_speedup = float(config['delivery'].get('poll_tau_speedup', 5))
         self._tau_slowdown = float(config['delivery'].get('poll_tau_slowdown', 60))
         self._jitter_ratio = float(config['delivery'].get('poll_jitter_ratio', 0.1))

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -9,6 +9,7 @@ import concurrent.futures
 import functools
 import itertools
 import logging
+import random
 import threading
 from collections.abc import Callable, Coroutine, Iterable
 from types import TracebackType
@@ -645,6 +646,8 @@ class DeliveryRunner(Runner):
 
     async def _run_poller(self, key: CacheKey, instance: Connector) -> None:
         tenant_uuid, backend = key
+        if self._jitter_ratio > 0:
+            await asyncio.sleep(random.uniform(0, self._poll_min))
         controller = CadenceController(
             poll_min=self._poll_min,
             poll_max=self._poll_max,

--- a/wazo_chatd/plugins/connectors/runner.py
+++ b/wazo_chatd/plugins/connectors/runner.py
@@ -26,6 +26,7 @@ from wazo_chatd.database.async_helpers import (
 )
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict
 from wazo_chatd.plugin_helpers.queue import AsyncQueue, QueueFull
+from wazo_chatd.plugins.connectors.cadence import CadenceController
 from wazo_chatd.plugins.connectors.connector import Connector
 from wazo_chatd.plugins.connectors.exceptions import ConnectorRateLimited
 from wazo_chatd.plugins.connectors.executor import MAX_RETRY_AFTER, DeliveryExecutor
@@ -266,6 +267,8 @@ class DeliveryRunner(Runner):
         self._poll_min = float(config['delivery'].get('poll_interval_min', 5))
         self._poll_max = float(config['delivery'].get('poll_interval_max', 60))
         self._poll_default = float(config['delivery'].get('poll_interval_default', 30))
+        self._tau_speedup = float(config['delivery'].get('poll_tau_speedup', 5))
+        self._tau_slowdown = float(config['delivery'].get('poll_tau_slowdown', 60))
 
         self._db_uri = str(config.get('db_uri', ''))
         engine, session_factory = init_async_db(self._db_uri)
@@ -641,24 +644,35 @@ class DeliveryRunner(Runner):
 
     async def _run_poller(self, key: CacheKey, instance: Connector) -> None:
         tenant_uuid, backend = key
-        interval = self._poll_min
+        controller = CadenceController(
+            poll_min=self._poll_min,
+            poll_max=self._poll_max,
+            tau_speedup=self._tau_speedup,
+            tau_slowdown=self._tau_slowdown,
+        )
+        prev_dt = self._poll_min
         while True:
             try:
                 yielded = await self._scan_inbound(instance, key)
                 yielded |= await self._track_outbound(instance, tenant_uuid, backend)
-                interval = (
-                    self._poll_min if yielded else min(interval * 2, self._poll_max)
-                )
+                controller.step(yielded=yielded, dt=prev_dt)
             except asyncio.CancelledError:
                 logger.info('Poller for %s cancelled', key)
                 raise
             except ConnectorRateLimited as exc:
-                interval = min(exc.retry_after, MAX_RETRY_AFTER)
-                logger.info('Poller for %s rate-limited, sleeping %.1fs', key, interval)
+                sleep_for = min(exc.retry_after, MAX_RETRY_AFTER)
+                logger.info(
+                    'Poller for %s rate-limited, sleeping %.1fs', key, sleep_for
+                )
+                await asyncio.sleep(sleep_for)
+                prev_dt = sleep_for
+                continue
             except Exception:
                 logger.exception('Poller for %s hit unexpected error, continuing', key)
-                interval = min(interval * 2, self._poll_max)
-            await asyncio.sleep(interval)
+                controller.step(yielded=False, dt=prev_dt)
+            sleep_for = controller.next_interval()
+            await asyncio.sleep(sleep_for)
+            prev_dt = sleep_for
 
     async def _scan_inbound(self, instance: Connector, key: CacheKey) -> bool:
         try:

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -105,6 +105,72 @@ class TestCadenceControllerStability:
         assert controller.next_interval() == 60.0
 
 
+class TestCadenceControllerRateLimitFloor:
+    def test_no_penalty_returns_poll_min_floor(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, rate_limit_floor=30.0,
+        )
+
+        assert controller.effective_min() == 5.0
+
+    def test_active_penalty_raises_floor(self) -> None:
+        now = [100.0]
+        controller = CadenceController(
+            poll_min=5.0,
+            poll_max=60.0,
+            rate_limit_floor=30.0,
+            clock=lambda: now[0],
+        )
+
+        controller.penalize(duration=300.0)
+
+        assert controller.effective_min() == 30.0
+
+    def test_expired_penalty_drops_back_to_poll_min(self) -> None:
+        now = [100.0]
+        controller = CadenceController(
+            poll_min=5.0,
+            poll_max=60.0,
+            rate_limit_floor=30.0,
+            clock=lambda: now[0],
+        )
+
+        controller.penalize(duration=100.0)
+        now[0] = 250.0
+
+        assert controller.effective_min() == 5.0
+
+    def test_yield_under_penalty_pulls_to_floor_not_poll_min(self) -> None:
+        now = [100.0]
+        controller = CadenceController(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=1.0,
+            rate_limit_floor=30.0,
+            clock=lambda: now[0],
+        )
+        controller.interval = 60.0
+        controller.penalize(duration=300.0)
+
+        controller.step(yielded=True, dt=10.0)
+
+        assert controller.next_interval() == pytest.approx(30.0)
+
+    def test_next_interval_clamps_to_floor_while_penalized(self) -> None:
+        now = [100.0]
+        controller = CadenceController(
+            poll_min=5.0,
+            poll_max=60.0,
+            rate_limit_floor=30.0,
+            clock=lambda: now[0],
+        )
+        controller.interval = 5.0
+
+        controller.penalize(duration=300.0)
+
+        assert controller.next_interval() == 30.0
+
+
 class TestApplyJitter:
     def test_zero_ratio_returns_base_value(self) -> None:
         assert apply_jitter(10.0, ratio=0.0) == 10.0

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -7,170 +7,265 @@ import random
 
 import pytest
 
-from wazo_chatd.plugins.connectors.cadence import CadenceController, apply_jitter
+from wazo_chatd.plugins.connectors.cadence import PollerCadence, apply_jitter
 
 
-class TestCadenceControllerColdStart:
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class TestPollerCadenceColdStart:
     def test_initial_interval_is_poll_min(self) -> None:
-        controller = CadenceController(poll_min=5.0, poll_max=60.0)
+        cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
 
-        assert controller.next_interval() == 5.0
+        assert cadence.next_interval() == 5.0
 
 
-class TestCadenceControllerYieldStep:
+class TestPollerCadenceYieldStep:
     def test_yield_at_poll_min_keeps_interval_at_poll_min(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
 
-        controller.step(yielded=True, dt=5.0)
+        clock.advance(5.0)
+        cadence.step(did_work=True)
 
-        assert controller.next_interval() == pytest.approx(5.0)
+        assert cadence.next_interval() == pytest.approx(5.0)
 
     def test_yield_from_poll_max_full_dt_pulls_to_poll_min(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
-        controller.interval = 60.0
+        cadence.interval = 60.0
 
-        controller.step(yielded=True, dt=5.0)
+        clock.advance(5.0)
+        cadence.step(did_work=True)
 
-        assert controller.next_interval() == pytest.approx(5.0)
+        assert cadence.next_interval() == pytest.approx(5.0)
 
     def test_yield_partial_dt_partial_movement(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
-        controller.interval = 60.0
+        cadence.interval = 60.0
 
-        controller.step(yielded=True, dt=2.5)
+        clock.advance(2.5)
+        cadence.step(did_work=True)
 
-        assert controller.next_interval() == pytest.approx(32.5)
+        assert cadence.next_interval() == pytest.approx(32.5)
 
 
-class TestCadenceControllerEmptyStep:
+class TestPollerCadenceEmptyStep:
     def test_empty_full_dt_pushes_to_poll_max(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
 
-        controller.step(yielded=False, dt=60.0)
+        clock.advance(60.0)
+        cadence.step(did_work=False)
 
-        assert controller.next_interval() == pytest.approx(60.0)
+        assert cadence.next_interval() == pytest.approx(60.0)
 
     def test_empty_partial_dt_partial_decay(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
 
-        controller.step(yielded=False, dt=30.0)
+        clock.advance(30.0)
+        cadence.step(did_work=False)
 
-        assert controller.next_interval() == pytest.approx(32.5)
+        assert cadence.next_interval() == pytest.approx(32.5)
 
     def test_repeated_empty_cycles_converge_to_poll_max(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
 
         for _ in range(50):
-            controller.step(yielded=False, dt=10.0)
+            clock.advance(10.0)
+            cadence.step(did_work=False)
 
-        assert controller.next_interval() == pytest.approx(60.0, abs=0.01)
+        assert cadence.next_interval() == pytest.approx(60.0, abs=0.01)
 
 
-class TestCadenceControllerStability:
+class TestPollerCadenceStability:
     def test_dt_above_tau_clamps_to_one_step(self) -> None:
-        controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
         )
 
-        controller.step(yielded=False, dt=600.0)
+        clock.advance(600.0)
+        cadence.step(did_work=False)
 
-        assert controller.next_interval() == pytest.approx(60.0)
+        assert cadence.next_interval() == pytest.approx(60.0)
 
     def test_interval_bounded_below_at_poll_min(self) -> None:
-        controller = CadenceController(poll_min=5.0, poll_max=60.0)
-        controller.interval = 3.0
+        cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
+        cadence.interval = 3.0
 
-        controller.step(yielded=True, dt=0.0)
+        cadence.step(did_work=True)
 
-        assert controller.next_interval() == 5.0
+        assert cadence.next_interval() == 5.0
 
     def test_interval_bounded_above_at_poll_max(self) -> None:
-        controller = CadenceController(poll_min=5.0, poll_max=60.0)
-        controller.interval = 100.0
+        cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
+        cadence.interval = 100.0
 
-        controller.step(yielded=False, dt=0.0)
+        cadence.step(did_work=False)
 
-        assert controller.next_interval() == 60.0
+        assert cadence.next_interval() == 60.0
 
 
-class TestCadenceControllerRateLimitFloor:
+class TestPollerCadenceRateLimitFloor:
     def test_no_penalty_returns_poll_min_floor(self) -> None:
-        controller = CadenceController(
+        cadence = PollerCadence(
             poll_min=5.0,
             poll_max=60.0,
             rate_limit_floor=30.0,
+            clock=FakeClock(),
         )
 
-        assert controller.effective_min() == 5.0
+        assert cadence.effective_min() == 5.0
 
     def test_active_penalty_raises_floor(self) -> None:
-        now = [100.0]
-        controller = CadenceController(
+        clock = FakeClock(start=100.0)
+        cadence = PollerCadence(
             poll_min=5.0,
             poll_max=60.0,
             rate_limit_floor=30.0,
-            clock=lambda: now[0],
+            clock=clock,
         )
 
-        controller.penalize(duration=300.0)
+        cadence.penalize(duration=300.0)
 
-        assert controller.effective_min() == 30.0
+        assert cadence.effective_min() == 30.0
 
     def test_expired_penalty_drops_back_to_poll_min(self) -> None:
-        now = [100.0]
-        controller = CadenceController(
+        clock = FakeClock(start=100.0)
+        cadence = PollerCadence(
             poll_min=5.0,
             poll_max=60.0,
             rate_limit_floor=30.0,
-            clock=lambda: now[0],
+            clock=clock,
         )
 
-        controller.penalize(duration=100.0)
-        now[0] = 250.0
+        cadence.penalize(duration=100.0)
+        clock.now = 250.0
 
-        assert controller.effective_min() == 5.0
+        assert cadence.effective_min() == 5.0
 
     def test_yield_under_penalty_pulls_to_floor_not_poll_min(self) -> None:
-        now = [100.0]
-        controller = CadenceController(
+        clock = FakeClock(start=100.0)
+        cadence = PollerCadence(
             poll_min=5.0,
             poll_max=60.0,
             tau_speedup=1.0,
             rate_limit_floor=30.0,
-            clock=lambda: now[0],
+            clock=clock,
         )
-        controller.interval = 60.0
-        controller.penalize(duration=300.0)
+        cadence.interval = 60.0
+        cadence.penalize(duration=300.0)
 
-        controller.step(yielded=True, dt=10.0)
+        clock.advance(10.0)
+        cadence.step(did_work=True)
 
-        assert controller.next_interval() == pytest.approx(30.0)
+        assert cadence.next_interval() == pytest.approx(30.0)
 
     def test_next_interval_clamps_to_floor_while_penalized(self) -> None:
-        now = [100.0]
-        controller = CadenceController(
+        clock = FakeClock(start=100.0)
+        cadence = PollerCadence(
             poll_min=5.0,
             poll_max=60.0,
             rate_limit_floor=30.0,
-            clock=lambda: now[0],
+            clock=clock,
         )
-        controller.interval = 5.0
+        cadence.interval = 5.0
 
-        controller.penalize(duration=300.0)
+        cadence.penalize(duration=300.0)
 
-        assert controller.next_interval() == 30.0
+        assert cadence.next_interval() == 30.0
+
+
+class TestPollerCadenceElapsedTracking:
+    def test_step_uses_elapsed_since_last_step(self) -> None:
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
+        )
+        cadence.interval = 60.0
+
+        clock.advance(2.5)
+        cadence.step(did_work=True)
+        first = cadence.next_interval()
+
+        clock.advance(2.5)
+        cadence.step(did_work=True)
+        second = cadence.next_interval()
+
+        assert first == pytest.approx(32.5)
+        assert second == pytest.approx(18.75)
+
+    def test_penalize_does_not_consume_elapsed(self) -> None:
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
+        )
+
+        clock.advance(60.0)
+        cadence.penalize(duration=300.0)
+        cadence.step(did_work=False)
+
+        assert cadence.next_interval() == pytest.approx(60.0)
 
 
 class TestApplyJitter:

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -1,0 +1,103 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import pytest
+
+from wazo_chatd.plugins.connectors.cadence import CadenceController
+
+
+class TestCadenceControllerColdStart:
+    def test_initial_interval_is_poll_min(self) -> None:
+        controller = CadenceController(poll_min=5.0, poll_max=60.0)
+
+        assert controller.next_interval() == 5.0
+
+
+class TestCadenceControllerYieldStep:
+    def test_yield_at_poll_min_keeps_interval_at_poll_min(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+
+        controller.step(yielded=True, dt=5.0)
+
+        assert controller.next_interval() == pytest.approx(5.0)
+
+    def test_yield_from_poll_max_full_dt_pulls_to_poll_min(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+        controller.interval = 60.0
+
+        controller.step(yielded=True, dt=5.0)
+
+        assert controller.next_interval() == pytest.approx(5.0)
+
+    def test_yield_partial_dt_partial_movement(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+        controller.interval = 60.0
+
+        controller.step(yielded=True, dt=2.5)
+
+        assert controller.next_interval() == pytest.approx(32.5)
+
+
+class TestCadenceControllerEmptyStep:
+    def test_empty_full_dt_pushes_to_poll_max(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+
+        controller.step(yielded=False, dt=60.0)
+
+        assert controller.next_interval() == pytest.approx(60.0)
+
+    def test_empty_partial_dt_partial_decay(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+
+        controller.step(yielded=False, dt=30.0)
+
+        assert controller.next_interval() == pytest.approx(32.5)
+
+    def test_repeated_empty_cycles_converge_to_poll_max(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+
+        for _ in range(50):
+            controller.step(yielded=False, dt=10.0)
+
+        assert controller.next_interval() == pytest.approx(60.0, abs=0.01)
+
+
+class TestCadenceControllerStability:
+    def test_dt_above_tau_clamps_to_one_step(self) -> None:
+        controller = CadenceController(
+            poll_min=5.0, poll_max=60.0, tau_speedup=5.0, tau_slowdown=60.0
+        )
+
+        controller.step(yielded=False, dt=600.0)
+
+        assert controller.next_interval() == pytest.approx(60.0)
+
+    def test_interval_bounded_below_at_poll_min(self) -> None:
+        controller = CadenceController(poll_min=5.0, poll_max=60.0)
+        controller.interval = 3.0
+
+        controller.step(yielded=True, dt=0.0)
+
+        assert controller.next_interval() == 5.0
+
+    def test_interval_bounded_above_at_poll_max(self) -> None:
+        controller = CadenceController(poll_min=5.0, poll_max=60.0)
+        controller.interval = 100.0
+
+        controller.step(yielded=False, dt=0.0)
+
+        assert controller.next_interval() == 60.0

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -25,7 +25,7 @@ class TestPollerCadenceColdStart:
     def test_initial_interval_is_poll_min(self) -> None:
         cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
 
-        assert cadence.next_interval() == 5.0
+        assert cadence.next_interval() == pytest.approx(5.0)
 
 
 class TestPollerCadenceYieldStep:
@@ -147,7 +147,7 @@ class TestPollerCadenceStability:
 
         cadence.step(did_work=True)
 
-        assert cadence.next_interval() == 5.0
+        assert cadence.next_interval() == pytest.approx(5.0)
 
     def test_interval_bounded_above_at_poll_max(self) -> None:
         cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
@@ -155,7 +155,7 @@ class TestPollerCadenceStability:
 
         cadence.step(did_work=False)
 
-        assert cadence.next_interval() == 60.0
+        assert cadence.next_interval() == pytest.approx(60.0)
 
 
 class TestPollerCadenceRateLimitFloor:
@@ -167,7 +167,7 @@ class TestPollerCadenceRateLimitFloor:
             clock=FakeClock(),
         )
 
-        assert cadence.effective_min() == 5.0
+        assert cadence.effective_min() == pytest.approx(5.0)
 
     def test_active_penalty_raises_floor(self) -> None:
         clock = FakeClock(start=100.0)
@@ -180,7 +180,7 @@ class TestPollerCadenceRateLimitFloor:
 
         cadence.penalize(duration=300.0)
 
-        assert cadence.effective_min() == 30.0
+        assert cadence.effective_min() == pytest.approx(30.0)
 
     def test_expired_penalty_drops_back_to_poll_min(self) -> None:
         clock = FakeClock(start=100.0)
@@ -194,7 +194,7 @@ class TestPollerCadenceRateLimitFloor:
         cadence.penalize(duration=100.0)
         clock.now = 250.0
 
-        assert cadence.effective_min() == 5.0
+        assert cadence.effective_min() == pytest.approx(5.0)
 
     def test_yield_under_penalty_pulls_to_floor_not_poll_min(self) -> None:
         clock = FakeClock(start=100.0)
@@ -225,7 +225,7 @@ class TestPollerCadenceRateLimitFloor:
 
         cadence.penalize(duration=300.0)
 
-        assert cadence.next_interval() == 30.0
+        assert cadence.next_interval() == pytest.approx(30.0)
 
 
 class TestPollerCadenceElapsedTracking:
@@ -270,7 +270,7 @@ class TestPollerCadenceElapsedTracking:
 
 class TestApplyJitter:
     def test_zero_ratio_returns_base_value(self) -> None:
-        assert apply_jitter(10.0, ratio=0.0) == 10.0
+        assert apply_jitter(10.0, ratio=0.0) == pytest.approx(10.0)
 
     def test_jittered_value_stays_within_ratio(self) -> None:
         rng = random.Random(42)
@@ -286,4 +286,4 @@ class TestApplyJitter:
         result_a = apply_jitter(10.0, ratio=0.1, rng=rng_a)
         result_b = apply_jitter(10.0, ratio=0.1, rng=rng_b)
 
-        assert result_a == result_b
+        assert result_a == pytest.approx(result_b)

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -28,8 +28,25 @@ class TestPollerCadenceColdStart:
         assert cadence.next_interval() == pytest.approx(5.0)
 
 
-class TestPollerCadenceYieldStep:
-    def test_yield_at_poll_min_keeps_interval_at_poll_min(self) -> None:
+class TestPollerCadenceStep:
+    @pytest.mark.parametrize(
+        ('initial', 'did_work', 'dt', 'expected'),
+        [
+            pytest.param(5.0, True, 5.0, 5.0, id='yield_at_poll_min_stays'),
+            pytest.param(60.0, True, 5.0, 5.0, id='yield_full_dt_pulls_to_poll_min'),
+            pytest.param(60.0, True, 2.5, 32.5, id='yield_partial_dt_partial_movement'),
+            pytest.param(5.0, False, 60.0, 60.0, id='empty_full_dt_pushes_to_poll_max'),
+            pytest.param(5.0, False, 30.0, 32.5, id='empty_partial_dt_partial_decay'),
+            pytest.param(5.0, False, 600.0, 60.0, id='empty_dt_above_tau_clamps'),
+        ],
+    )
+    def test_step_moves_interval(
+        self,
+        initial: float,
+        did_work: bool,
+        dt: float,
+        expected: float,
+    ) -> None:
         clock = FakeClock()
         cadence = PollerCadence(
             poll_min=5.0,
@@ -38,75 +55,12 @@ class TestPollerCadenceYieldStep:
             tau_slowdown=60.0,
             clock=clock,
         )
+        cadence.interval = initial
 
-        clock.advance(5.0)
-        cadence.step(did_work=True)
+        clock.advance(dt)
+        cadence.step(did_work=did_work)
 
-        assert cadence.next_interval() == pytest.approx(5.0)
-
-    def test_yield_from_poll_max_full_dt_pulls_to_poll_min(self) -> None:
-        clock = FakeClock()
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            tau_speedup=5.0,
-            tau_slowdown=60.0,
-            clock=clock,
-        )
-        cadence.interval = 60.0
-
-        clock.advance(5.0)
-        cadence.step(did_work=True)
-
-        assert cadence.next_interval() == pytest.approx(5.0)
-
-    def test_yield_partial_dt_partial_movement(self) -> None:
-        clock = FakeClock()
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            tau_speedup=5.0,
-            tau_slowdown=60.0,
-            clock=clock,
-        )
-        cadence.interval = 60.0
-
-        clock.advance(2.5)
-        cadence.step(did_work=True)
-
-        assert cadence.next_interval() == pytest.approx(32.5)
-
-
-class TestPollerCadenceEmptyStep:
-    def test_empty_full_dt_pushes_to_poll_max(self) -> None:
-        clock = FakeClock()
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            tau_speedup=5.0,
-            tau_slowdown=60.0,
-            clock=clock,
-        )
-
-        clock.advance(60.0)
-        cadence.step(did_work=False)
-
-        assert cadence.next_interval() == pytest.approx(60.0)
-
-    def test_empty_partial_dt_partial_decay(self) -> None:
-        clock = FakeClock()
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            tau_speedup=5.0,
-            tau_slowdown=60.0,
-            clock=clock,
-        )
-
-        clock.advance(30.0)
-        cadence.step(did_work=False)
-
-        assert cadence.next_interval() == pytest.approx(32.5)
+        assert cadence.next_interval() == pytest.approx(expected)
 
     def test_repeated_empty_cycles_converge_to_poll_max(self) -> None:
         clock = FakeClock()
@@ -125,22 +79,7 @@ class TestPollerCadenceEmptyStep:
         assert cadence.next_interval() == pytest.approx(60.0, abs=0.01)
 
 
-class TestPollerCadenceStability:
-    def test_dt_above_tau_clamps_to_one_step(self) -> None:
-        clock = FakeClock()
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            tau_speedup=5.0,
-            tau_slowdown=60.0,
-            clock=clock,
-        )
-
-        clock.advance(600.0)
-        cadence.step(did_work=False)
-
-        assert cadence.next_interval() == pytest.approx(60.0)
-
+class TestPollerCadenceBounds:
     def test_interval_bounded_below_at_poll_min(self) -> None:
         cadence = PollerCadence(poll_min=5.0, poll_max=60.0, clock=FakeClock())
         cadence.interval = 3.0
@@ -159,17 +98,20 @@ class TestPollerCadenceStability:
 
 
 class TestPollerCadenceRateLimitFloor:
-    def test_no_penalty_returns_poll_min_floor(self) -> None:
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            rate_limit_floor=30.0,
-            clock=FakeClock(),
-        )
-
-        assert cadence.effective_min() == pytest.approx(5.0)
-
-    def test_active_penalty_raises_floor(self) -> None:
+    @pytest.mark.parametrize(
+        ('penalty_duration', 'time_after_penalty', 'expected'),
+        [
+            pytest.param(None, 0.0, 5.0, id='no_penalty'),
+            pytest.param(300.0, 0.0, 30.0, id='active_penalty'),
+            pytest.param(100.0, 150.0, 5.0, id='expired_penalty'),
+        ],
+    )
+    def test_effective_min(
+        self,
+        penalty_duration: float | None,
+        time_after_penalty: float,
+        expected: float,
+    ) -> None:
         clock = FakeClock(start=100.0)
         cadence = PollerCadence(
             poll_min=5.0,
@@ -177,24 +119,11 @@ class TestPollerCadenceRateLimitFloor:
             rate_limit_floor=30.0,
             clock=clock,
         )
+        if penalty_duration is not None:
+            cadence.penalize(duration=penalty_duration)
+        clock.advance(time_after_penalty)
 
-        cadence.penalize(duration=300.0)
-
-        assert cadence.effective_min() == pytest.approx(30.0)
-
-    def test_expired_penalty_drops_back_to_poll_min(self) -> None:
-        clock = FakeClock(start=100.0)
-        cadence = PollerCadence(
-            poll_min=5.0,
-            poll_max=60.0,
-            rate_limit_floor=30.0,
-            clock=clock,
-        )
-
-        cadence.penalize(duration=100.0)
-        clock.now = 250.0
-
-        assert cadence.effective_min() == pytest.approx(5.0)
+        assert cadence.effective_min() == pytest.approx(expected)
 
     def test_yield_under_penalty_pulls_to_floor_not_poll_min(self) -> None:
         clock = FakeClock(start=100.0)
@@ -288,15 +217,9 @@ class TestPollerCadenceElapsedTracking:
 
 
 class TestApplyJitter:
-    def test_zero_ratio_returns_base_value(self) -> None:
-        assert apply_jitter(10.0, ratio=0.0) == pytest.approx(10.0)
-
-    def test_ratio_at_or_above_one_returns_base_value(self) -> None:
-        assert apply_jitter(10.0, ratio=1.0) == pytest.approx(10.0)
-        assert apply_jitter(10.0, ratio=1.5) == pytest.approx(10.0)
-
-    def test_negative_ratio_returns_base_value(self) -> None:
-        assert apply_jitter(10.0, ratio=-0.1) == pytest.approx(10.0)
+    @pytest.mark.parametrize('ratio', [-0.1, 0.0, 1.0, 1.5])
+    def test_out_of_range_ratio_returns_base_value(self, ratio: float) -> None:
+        assert apply_jitter(10.0, ratio=ratio) == pytest.approx(10.0)
 
     def test_jittered_value_stays_within_ratio(self) -> None:
         rng = random.Random(42)

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import random
+
 import pytest
 
-from wazo_chatd.plugins.connectors.cadence import CadenceController
+from wazo_chatd.plugins.connectors.cadence import CadenceController, apply_jitter
 
 
 class TestCadenceControllerColdStart:
@@ -101,3 +103,24 @@ class TestCadenceControllerStability:
         controller.step(yielded=False, dt=0.0)
 
         assert controller.next_interval() == 60.0
+
+
+class TestApplyJitter:
+    def test_zero_ratio_returns_base_value(self) -> None:
+        assert apply_jitter(10.0, ratio=0.0) == 10.0
+
+    def test_jittered_value_stays_within_ratio(self) -> None:
+        rng = random.Random(42)
+
+        for _ in range(100):
+            result = apply_jitter(10.0, ratio=0.1, rng=rng)
+            assert 9.0 <= result <= 11.0
+
+    def test_seeded_rng_is_deterministic(self) -> None:
+        rng_a = random.Random(42)
+        rng_b = random.Random(42)
+
+        result_a = apply_jitter(10.0, ratio=0.1, rng=rng_a)
+        result_b = apply_jitter(10.0, ratio=0.1, rng=rng_b)
+
+        assert result_a == result_b

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -267,10 +267,36 @@ class TestPollerCadenceElapsedTracking:
 
         assert cadence.next_interval() == pytest.approx(60.0)
 
+    def test_reset_step_clock_discards_elapsed_time(self) -> None:
+        clock = FakeClock()
+        cadence = PollerCadence(
+            poll_min=5.0,
+            poll_max=60.0,
+            tau_speedup=5.0,
+            tau_slowdown=60.0,
+            clock=clock,
+        )
+        cadence.interval = 60.0
+
+        clock.advance(60.0)
+        cadence.reset_step_clock()
+
+        clock.advance(2.5)
+        cadence.step(did_work=True)
+
+        assert cadence.next_interval() == pytest.approx(32.5)
+
 
 class TestApplyJitter:
     def test_zero_ratio_returns_base_value(self) -> None:
         assert apply_jitter(10.0, ratio=0.0) == pytest.approx(10.0)
+
+    def test_ratio_at_or_above_one_returns_base_value(self) -> None:
+        assert apply_jitter(10.0, ratio=1.0) == pytest.approx(10.0)
+        assert apply_jitter(10.0, ratio=1.5) == pytest.approx(10.0)
+
+    def test_negative_ratio_returns_base_value(self) -> None:
+        assert apply_jitter(10.0, ratio=-0.1) == pytest.approx(10.0)
 
     def test_jittered_value_stays_within_ratio(self) -> None:
         rng = random.Random(42)

--- a/wazo_chatd/plugins/connectors/tests/test_cadence.py
+++ b/wazo_chatd/plugins/connectors/tests/test_cadence.py
@@ -108,7 +108,9 @@ class TestCadenceControllerStability:
 class TestCadenceControllerRateLimitFloor:
     def test_no_penalty_returns_poll_min_floor(self) -> None:
         controller = CadenceController(
-            poll_min=5.0, poll_max=60.0, rate_limit_floor=30.0,
+            poll_min=5.0,
+            poll_max=60.0,
+            rate_limit_floor=30.0,
         )
 
         assert controller.effective_min() == 5.0

--- a/wazo_chatd/plugins/connectors/tests/test_executor.py
+++ b/wazo_chatd/plugins/connectors/tests/test_executor.py
@@ -233,7 +233,7 @@ class TestDeliveryExecutorOutboundSend(unittest.IsolatedAsyncioTestCase):
 
         result = await self.executor.route_outbound_delivery('1')
 
-        assert result == 30.0
+        assert result == pytest.approx(30.0)
 
     async def test_rate_limited_returns_provider_retry_after(self) -> None:
         self.connector.send_side_effect = ConnectorRateLimited(
@@ -242,7 +242,7 @@ class TestDeliveryExecutorOutboundSend(unittest.IsolatedAsyncioTestCase):
 
         result = await self.executor.route_outbound_delivery('1')
 
-        assert result == 42.0
+        assert result == pytest.approx(42.0)
 
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         self.connector.send_side_effect = ConnectorRateLimited(
@@ -251,7 +251,7 @@ class TestDeliveryExecutorOutboundSend(unittest.IsolatedAsyncioTestCase):
 
         result = await self.executor.route_outbound_delivery('1')
 
-        assert result == 3600.0
+        assert result == pytest.approx(3600.0)
 
     async def test_rate_limited_still_increments_retry_count(self) -> None:
         self.connector.send_side_effect = ConnectorRateLimited(
@@ -939,7 +939,10 @@ class TestDeliveryExecutorRecovery(unittest.IsolatedAsyncioTestCase):
 
         result = await self.executor.recover_pending_deliveries()
 
-        assert result == [('42', 0.0)]
+        assert len(result) == 1
+        delivery_id, delay = result[0]
+        assert delivery_id == '42'
+        assert delay == pytest.approx(0.0)
 
     async def test_retrying_delivery_recovered_with_delay(self) -> None:
         self.executor._room_dao.get_recoverable_deliveries = AsyncMock(
@@ -950,14 +953,14 @@ class TestDeliveryExecutorRecovery(unittest.IsolatedAsyncioTestCase):
 
         assert len(result) == 1
         _, delay = result[0]
-        assert delay == 30.0
+        assert delay == pytest.approx(30.0)
 
 
 class TestConnectorRateLimitedException(unittest.TestCase):
     def test_carries_retry_after(self) -> None:
         exc = ConnectorRateLimited('rate limited', retry_after=120.0)
 
-        assert exc.retry_after == 120.0
+        assert exc.retry_after == pytest.approx(120.0)
         assert str(exc) == 'rate limited'
 
     def test_is_subclass_of_connector_send_error(self) -> None:

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -482,9 +482,9 @@ class TestDeliveryRunnerPollCycle(unittest.IsolatedAsyncioTestCase):
         message = _make_inbound()
         instance = Mock(scan_inbound=Mock(return_value=[message]))
 
-        yielded = await loop._scan_inbound(instance, ('tenant', 'backend'))
+        did_work = await loop._scan_inbound(instance, ('tenant', 'backend'))
 
-        assert yielded is True
+        assert did_work is True
         loop.enqueue_message.assert_any_call(message)
 
     async def test_track_outbound_skipped_when_no_pending(self) -> None:
@@ -492,9 +492,9 @@ class TestDeliveryRunnerPollCycle(unittest.IsolatedAsyncioTestCase):
         instance = Mock()
         instance.track_outbound = Mock(return_value=[])
 
-        yielded = await loop._track_outbound(instance, 'tenant', 'backend')
+        did_work = await loop._track_outbound(instance, 'tenant', 'backend')
 
-        assert yielded is False
+        assert did_work is False
         instance.track_outbound.assert_not_called()
 
     async def test_track_outbound_called_with_pending_ids(self) -> None:
@@ -505,9 +505,9 @@ class TestDeliveryRunnerPollCycle(unittest.IsolatedAsyncioTestCase):
         instance = Mock()
         instance.track_outbound = Mock(return_value=[update])
 
-        yielded = await loop._track_outbound(instance, 'tenant', 'backend')
+        did_work = await loop._track_outbound(instance, 'tenant', 'backend')
 
-        assert yielded is True
+        assert did_work is True
         instance.track_outbound.assert_called_once_with(['ext-1', 'ext-2'])
         loop.enqueue_message.assert_any_call(update)
 
@@ -520,18 +520,18 @@ class TestDeliveryRunnerPollCycle(unittest.IsolatedAsyncioTestCase):
 
         instance = Mock(scan_inbound=async_scan)
 
-        yielded = await loop._scan_inbound(instance, ('tenant', 'backend'))
+        did_work = await loop._scan_inbound(instance, ('tenant', 'backend'))
 
-        assert yielded is True
+        assert did_work is True
         loop.enqueue_message.assert_any_call(message)
 
     async def test_scan_exception_logged_returns_false(self) -> None:
         loop = self._make_loop()
         instance = Mock(scan_inbound=Mock(side_effect=RuntimeError('boom')))
 
-        yielded = await loop._scan_inbound(instance, ('tenant', 'backend'))
+        did_work = await loop._scan_inbound(instance, ('tenant', 'backend'))
 
-        assert yielded is False
+        assert did_work is False
         loop.enqueue_message.assert_not_called()
 
 
@@ -558,6 +558,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
     async def test_empty_cycles_grow_interval_toward_poll_max(self) -> None:
         loop = self._make_loop()
         intervals: list[float] = []
+        fake_now = [0.0]
 
         async def fake_scan(*_args: object) -> bool:
             return False
@@ -570,10 +571,14 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
+            fake_now[0] += d
             if len(intervals) >= 5:
                 raise asyncio.CancelledError()
 
         with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.monotonic',
+            lambda: fake_now[0],
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -705,8 +705,43 @@ class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert all(4.5 <= i <= 5.5 for i in intervals)
-        assert len(set(intervals)) > 1
+        spawn_sleep, *step_sleeps = intervals
+        assert 0 <= spawn_sleep <= 5
+        assert all(4.5 <= i <= 5.5 for i in step_sleeps)
+        assert len(set(step_sleeps)) > 1
+
+    async def test_first_sleep_is_spawn_jitter_in_zero_poll_min_range(
+        self,
+    ) -> None:
+        loop = self._make_loop()
+        intervals: list[float] = []
+
+        async def fake_scan(*_args: object) -> bool:
+            return False
+
+        async def fake_track(*_args: object) -> bool:
+            return False
+
+        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
+        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
+
+        async def capture_sleep(d: float) -> None:
+            intervals.append(d)
+            raise asyncio.CancelledError()
+
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform',
+            return_value=2.5,
+        ) as mock_uniform:
+            with unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
+                capture_sleep,
+            ):
+                with self.assertRaises(asyncio.CancelledError):
+                    await loop._run_poller(('tenant', 'backend'), Mock())
+
+        assert intervals == [2.5]
+        mock_uniform.assert_called_once_with(0, 5.0)
 
 
 def _build_loop_for_modes(connectors_config: dict) -> DeliveryRunner:

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -592,6 +592,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
     async def test_yield_pulls_interval_back_toward_poll_min(self) -> None:
         loop = self._make_loop()
         intervals: list[float] = []
+        fake_now = [0.0]
         call_count = {'n': 0}
 
         async def fake_scan(*_args: object) -> bool:
@@ -606,10 +607,14 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
+            fake_now[0] += d
             if len(intervals) >= 4:
                 raise asyncio.CancelledError()
 
         with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.monotonic',
+            lambda: fake_now[0],
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -549,6 +549,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             'poll_interval_default': 2,
             'poll_tau_speedup': 1,
             'poll_tau_slowdown': 4,
+            'poll_jitter_ratio': 0,
         }
         return DeliveryRunner(config, Mock(), Mock())
 
@@ -661,6 +662,51 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
         assert intervals == [3600.0]
+
+
+class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.init_async_db')
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.BusPublisher')
+    def _make_loop(self, mock_bus: Mock, mock_init_db: Mock) -> DeliveryRunner:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        config = _make_config()
+        config['delivery'] = {
+            **config['delivery'],
+            'poll_interval_min': 5,
+            'poll_interval_max': 5,
+            'poll_tau_speedup': 1,
+            'poll_tau_slowdown': 1,
+            'poll_jitter_ratio': 0.1,
+        }
+        return DeliveryRunner(config, Mock(), Mock())
+
+    async def test_jitter_introduces_variance_at_fixed_interval(self) -> None:
+        loop = self._make_loop()
+        intervals: list[float] = []
+
+        async def fake_scan(*_args: object) -> bool:
+            return False
+
+        async def fake_track(*_args: object) -> bool:
+            return False
+
+        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
+        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
+
+        async def capture_sleep(d: float) -> None:
+            intervals.append(d)
+            if len(intervals) >= 20:
+                raise asyncio.CancelledError()
+
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await loop._run_poller(('tenant', 'backend'), Mock())
+
+        assert all(4.5 <= i <= 5.5 for i in intervals)
+        assert len(set(intervals)) > 1
 
 
 def _build_loop_for_modes(connectors_config: dict) -> DeliveryRunner:

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -10,6 +10,8 @@ import unittest
 import unittest.mock
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict
 from wazo_chatd.plugins.connectors import runner as runner_module
 from wazo_chatd.plugins.connectors.exceptions import ConnectorRateLimited
@@ -545,10 +547,12 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             'poll_interval_min': 1,
             'poll_interval_max': 8,
             'poll_interval_default': 2,
+            'poll_tau_speedup': 1,
+            'poll_tau_slowdown': 4,
         }
         return DeliveryRunner(config, Mock(), Mock())
 
-    async def test_empty_cycles_double_up_to_max(self) -> None:
+    async def test_empty_cycles_grow_interval_toward_poll_max(self) -> None:
         loop = self._make_loop()
         intervals: list[float] = []
 
@@ -572,9 +576,12 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == [2, 4, 8, 8, 8]
+        assert all(loop._poll_min <= i <= loop._poll_max for i in intervals)
+        assert intervals[1] > intervals[0]
+        assert intervals[2] > intervals[1]
+        assert intervals[-1] == pytest.approx(loop._poll_max, abs=0.01)
 
-    async def test_non_empty_cycle_snaps_to_min(self) -> None:
+    async def test_yield_pulls_interval_back_toward_poll_min(self) -> None:
         loop = self._make_loop()
         intervals: list[float] = []
         call_count = {'n': 0}
@@ -600,10 +607,10 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals[0] == 2
-        assert intervals[1] == 4
-        assert intervals[2] == 1
-        assert intervals[3] == 2
+        assert intervals[1] > intervals[0]
+        assert intervals[2] < intervals[1]
+        assert intervals[2] == pytest.approx(loop._poll_min, abs=0.01)
+        assert intervals[3] > intervals[2]
 
     async def test_rate_limited_uses_provider_retry_after(self) -> None:
         loop = self._make_loop()

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -681,22 +681,30 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         assert intervals[1] == pytest.approx(42.0)
 
-    async def test_rate_limit_event_raises_floor_for_subsequent_polls(
+    async def _assert_subsequent_polls_use_floor(
         self,
+        exc: BaseException,
+        *,
+        max_intervals: int,
     ) -> None:
         loop = self._make_loop()
 
         intervals = await _run_poller_capturing_sleeps(
             loop,
-            scan=_raises_then_yields(
-                ConnectorRateLimited('throttle', retry_after=10.0)
-            ),
-            max_intervals=4,
+            scan=_raises_then_yields(exc),
+            max_intervals=max_intervals,
         )
 
-        assert intervals[1] == pytest.approx(10.0)
-        assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
-        assert intervals[3] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[-2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[-1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+
+    async def test_rate_limit_event_raises_floor_for_subsequent_polls(
+        self,
+    ) -> None:
+        await self._assert_subsequent_polls_use_floor(
+            ConnectorRateLimited('throttle', retry_after=10.0),
+            max_intervals=4,
+        )
 
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         loop = self._make_loop()
@@ -712,16 +720,10 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
         assert intervals[1] == pytest.approx(3600.0)
 
     async def test_unexpected_error_raises_floor_for_subsequent_polls(self) -> None:
-        loop = self._make_loop()
-
-        intervals = await _run_poller_capturing_sleeps(
-            loop,
-            scan=_raises_then_yields(RuntimeError('boom')),
+        await self._assert_subsequent_polls_use_floor(
+            RuntimeError('boom'),
             max_intervals=3,
         )
-
-        assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
-        assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
 
 
 class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -109,6 +109,7 @@ async def _run_poller_capturing_sleeps(
     track: Callable[..., Awaitable[bool]] = _no_work,
     max_intervals: int,
     fake_clock: bool = False,
+    uniform_return: float | None = 0.0,
 ) -> list[float]:
     intervals: list[float] = []
     fake_now = [0.0]
@@ -124,12 +125,13 @@ async def _run_poller_capturing_sleeps(
             raise asyncio.CancelledError()
 
     with contextlib.ExitStack() as stack:
-        stack.enter_context(
-            unittest.mock.patch(
-                'wazo_chatd.plugins.connectors.runner.random.uniform',
-                return_value=0,
+        if uniform_return is not None:
+            stack.enter_context(
+                unittest.mock.patch(
+                    'wazo_chatd.plugins.connectors.runner.random.uniform',
+                    return_value=uniform_return,
+                )
             )
-        )
         stack.enter_context(
             unittest.mock.patch(
                 'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
@@ -681,31 +683,6 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         assert intervals[1] == pytest.approx(42.0)
 
-    async def _assert_subsequent_polls_use_floor(
-        self,
-        exc: BaseException,
-        *,
-        max_intervals: int,
-    ) -> None:
-        loop = self._make_loop()
-
-        intervals = await _run_poller_capturing_sleeps(
-            loop,
-            scan=_raises_then_yields(exc),
-            max_intervals=max_intervals,
-        )
-
-        assert intervals[-2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
-        assert intervals[-1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
-
-    async def test_rate_limit_event_raises_floor_for_subsequent_polls(
-        self,
-    ) -> None:
-        await self._assert_subsequent_polls_use_floor(
-            ConnectorRateLimited('throttle', retry_after=10.0),
-            max_intervals=4,
-        )
-
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         loop = self._make_loop()
 
@@ -719,135 +696,89 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         assert intervals[1] == pytest.approx(3600.0)
 
-    async def test_unexpected_error_raises_floor_for_subsequent_polls(self) -> None:
-        await self._assert_subsequent_polls_use_floor(
-            RuntimeError('boom'),
-            max_intervals=3,
-        )
+    async def test_errors_raise_floor_for_subsequent_polls(self) -> None:
+        cases: list[tuple[BaseException, int]] = [
+            (ConnectorRateLimited('throttle', retry_after=10.0), 4),
+            (RuntimeError('boom'), 3),
+        ]
+        for exc, max_intervals in cases:
+            loop = self._make_loop()
+
+            intervals = await _run_poller_capturing_sleeps(
+                loop,
+                scan=_raises_then_yields(exc),
+                max_intervals=max_intervals,
+            )
+
+            assert intervals[-2] == pytest.approx(loop._rate_limit_floor, abs=0.01), exc
+            assert intervals[-1] == pytest.approx(loop._rate_limit_floor, abs=0.01), exc
 
 
 class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
-    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.init_async_db')
-    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.BusPublisher')
-    def _make_loop(self, mock_bus: Mock, mock_init_db: Mock) -> DeliveryRunner:
-        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
-        mock_bus.from_config.return_value = Mock()
-        config = _make_config()
-        config['delivery'] = {
-            **config['delivery'],
-            'poll_interval_min': 5,
-            'poll_interval_max': 5,
-            'poll_tau_speedup': 1,
-            'poll_tau_slowdown': 1,
-            'poll_jitter_ratio': 0.1,
-        }
-        return DeliveryRunner(config, Mock(), Mock())
+    def _make_loop(self, **delivery_overrides: object) -> DeliveryRunner:
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.init_async_db',
+            return_value=(AsyncMock(), _mock_session_factory()),
+        ), unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.BusPublisher',
+        ) as mock_bus:
+            mock_bus.from_config.return_value = Mock()
+            config = _make_config()
+            config['delivery'] = {
+                **config['delivery'],
+                'poll_interval_min': 5,
+                'poll_interval_max': 5,
+                'poll_tau_speedup': 1,
+                'poll_tau_slowdown': 1,
+                'poll_jitter_ratio': 0.1,
+                **delivery_overrides,
+            }
+            return DeliveryRunner(config, Mock(), Mock())
 
     async def test_jitter_introduces_variance_at_fixed_interval(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
 
-        async def fake_scan(*_args: object) -> bool:
-            return False
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            if len(intervals) >= 20:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_no_work,
+            max_intervals=20,
+            uniform_return=None,
+        )
 
         spawn_sleep, *step_sleeps = intervals
         assert 0 <= spawn_sleep <= 5
         assert all(4.5 <= i <= 5.5 for i in step_sleeps)
-        assert len(set(step_sleeps)) > 1
+        assert max(step_sleeps) - min(step_sleeps) > 0.3
+        assert len(set(step_sleeps)) >= len(step_sleeps) - 1
+
+    async def _assert_first_sleep_matches_spawn_jitter(
+        self, loop: DeliveryRunner
+    ) -> None:
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform',
+            return_value=2.5,
+        ) as mock_uniform:
+            intervals = await _run_poller_capturing_sleeps(
+                loop,
+                scan=_no_work,
+                max_intervals=1,
+                uniform_return=None,
+            )
+
+        assert intervals == pytest.approx([2.5])
+        mock_uniform.assert_called_once_with(0, 5.0)
 
     async def test_first_sleep_is_spawn_jitter_in_zero_poll_min_range(
         self,
     ) -> None:
-        loop = self._make_loop()
-        intervals: list[float] = []
+        await self._assert_first_sleep_matches_spawn_jitter(self._make_loop())
 
-        async def fake_scan(*_args: object) -> bool:
-            return False
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform',
-            return_value=2.5,
-        ) as mock_uniform:
-            with unittest.mock.patch(
-                'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
-                capture_sleep,
-            ):
-                with self.assertRaises(asyncio.CancelledError):
-                    await loop._run_poller(('tenant', 'backend'), Mock())
-
-        assert intervals == pytest.approx([2.5])
-        mock_uniform.assert_called_once_with(0, 5.0)
-
-    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.init_async_db')
-    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.BusPublisher')
     async def test_spawn_jitter_happens_even_when_step_jitter_disabled(
-        self, mock_bus: Mock, mock_init_db: Mock
+        self,
     ) -> None:
-        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
-        mock_bus.from_config.return_value = Mock()
-        config = _make_config()
-        config['delivery'] = {
-            **config['delivery'],
-            'poll_interval_min': 5,
-            'poll_interval_max': 5,
-            'poll_jitter_ratio': 0,
-        }
-        loop = DeliveryRunner(config, Mock(), Mock())
-        intervals: list[float] = []
-
-        async def fake_scan(*_args: object) -> bool:
-            return False
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform',
-            return_value=2.5,
-        ) as mock_uniform:
-            with unittest.mock.patch(
-                'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
-                capture_sleep,
-            ):
-                with self.assertRaises(asyncio.CancelledError):
-                    await loop._run_poller(('tenant', 'backend'), Mock())
-
-        assert intervals == pytest.approx([2.5])
-        mock_uniform.assert_called_once_with(0, 5.0)
+        await self._assert_first_sleep_matches_spawn_jitter(
+            self._make_loop(poll_jitter_ratio=0),
+        )
 
 
 def _build_loop_for_modes(connectors_config: dict) -> DeliveryRunner:

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -550,6 +550,8 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             'poll_tau_speedup': 1,
             'poll_tau_slowdown': 4,
             'poll_jitter_ratio': 0,
+            'poll_rate_limit_floor': 4,
+            'poll_rate_limit_window': 100,
         }
         return DeliveryRunner(config, Mock(), Mock())
 
@@ -637,6 +639,40 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
         assert intervals == [42.0]
+
+    async def test_rate_limit_event_raises_floor_for_subsequent_polls(
+        self,
+    ) -> None:
+        loop = self._make_loop()
+        intervals: list[float] = []
+        call_count = {'n': 0}
+
+        async def fake_scan(*_args: object) -> bool:
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                raise ConnectorRateLimited('throttle', retry_after=10.0)
+            return True
+
+        async def fake_track(*_args: object) -> bool:
+            return False
+
+        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
+        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
+
+        async def capture_sleep(d: float) -> None:
+            intervals.append(d)
+            if len(intervals) >= 3:
+                raise asyncio.CancelledError()
+
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await loop._run_poller(('tenant', 'backend'), Mock())
+
+        assert intervals[0] == 10.0
+        assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
 
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         loop = self._make_loop()

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -468,7 +468,6 @@ class TestDeliveryRunnerPollCycle(unittest.IsolatedAsyncioTestCase):
             **config['delivery'],
             'poll_interval_min': 1,
             'poll_interval_max': 8,
-            'poll_interval_default': 2,
         }
         loop = DeliveryRunner(config, Mock(), Mock())
         loop._executor._room_dao = Mock(
@@ -546,7 +545,6 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             **config['delivery'],
             'poll_interval_min': 1,
             'poll_interval_max': 8,
-            'poll_interval_default': 2,
             'poll_tau_speedup': 1,
             'poll_tau_slowdown': 4,
             'poll_jitter_ratio': 0,

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -570,22 +570,25 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
             fake_now[0] += d
-            if len(intervals) >= 5:
+            if len(intervals) >= 6:
                 raise asyncio.CancelledError()
 
         with unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.monotonic',
             lambda: fake_now[0],
         ), unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert all(loop._poll_min <= i <= loop._poll_max for i in intervals)
-        assert intervals[1] > intervals[0]
-        assert intervals[2] > intervals[1]
-        assert intervals[-1] == pytest.approx(loop._poll_max, abs=0.01)
+        _, *step_sleeps = intervals
+        assert all(loop._poll_min <= i <= loop._poll_max for i in step_sleeps)
+        assert step_sleeps[1] > step_sleeps[0]
+        assert step_sleeps[2] > step_sleeps[1]
+        assert step_sleeps[-1] == pytest.approx(loop._poll_max, abs=0.01)
 
     async def test_yield_pulls_interval_back_toward_poll_min(self) -> None:
         loop = self._make_loop()
@@ -606,22 +609,25 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
             fake_now[0] += d
-            if len(intervals) >= 4:
+            if len(intervals) >= 5:
                 raise asyncio.CancelledError()
 
         with unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.monotonic',
             lambda: fake_now[0],
         ), unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals[1] > intervals[0]
-        assert intervals[2] < intervals[1]
-        assert intervals[2] == pytest.approx(loop._poll_min, abs=0.01)
-        assert intervals[3] > intervals[2]
+        _, *step_sleeps = intervals
+        assert step_sleeps[1] > step_sleeps[0]
+        assert step_sleeps[2] < step_sleeps[1]
+        assert step_sleeps[2] == pytest.approx(loop._poll_min, abs=0.01)
+        assert step_sleeps[3] > step_sleeps[2]
 
     async def test_rate_limited_uses_provider_retry_after(self) -> None:
         loop = self._make_loop()
@@ -638,15 +644,18 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
-            raise asyncio.CancelledError()
+            if len(intervals) >= 2:
+                raise asyncio.CancelledError()
 
         with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == pytest.approx([42.0])
+        assert intervals[1] == pytest.approx(42.0)
 
     async def test_rate_limit_event_raises_floor_for_subsequent_polls(
         self,
@@ -669,18 +678,20 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
-            if len(intervals) >= 3:
+            if len(intervals) >= 4:
                 raise asyncio.CancelledError()
 
         with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals[0] == pytest.approx(10.0)
-        assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[1] == pytest.approx(10.0)
         assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[3] == pytest.approx(loop._rate_limit_floor, abs=0.01)
 
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         loop = self._make_loop()
@@ -697,15 +708,51 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
         async def capture_sleep(d: float) -> None:
             intervals.append(d)
-            raise asyncio.CancelledError()
+            if len(intervals) >= 2:
+                raise asyncio.CancelledError()
 
         with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
             'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
         ):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == pytest.approx([3600.0])
+        assert intervals[1] == pytest.approx(3600.0)
+
+    async def test_unexpected_error_raises_floor_for_subsequent_polls(self) -> None:
+        loop = self._make_loop()
+        intervals: list[float] = []
+        call_count = {'n': 0}
+
+        async def fake_scan(*_args: object) -> bool:
+            call_count['n'] += 1
+            if call_count['n'] == 1:
+                raise RuntimeError('boom')
+            return True
+
+        async def fake_track(*_args: object) -> bool:
+            return False
+
+        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
+        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
+
+        async def capture_sleep(d: float) -> None:
+            intervals.append(d)
+            if len(intervals) >= 3:
+                raise asyncio.CancelledError()
+
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
+        ), unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await loop._run_poller(('tenant', 'backend'), Mock())
+
+        assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
+        assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
 
 
 class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
@@ -758,6 +805,50 @@ class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
         self,
     ) -> None:
         loop = self._make_loop()
+        intervals: list[float] = []
+
+        async def fake_scan(*_args: object) -> bool:
+            return False
+
+        async def fake_track(*_args: object) -> bool:
+            return False
+
+        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
+        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
+
+        async def capture_sleep(d: float) -> None:
+            intervals.append(d)
+            raise asyncio.CancelledError()
+
+        with unittest.mock.patch(
+            'wazo_chatd.plugins.connectors.runner.random.uniform',
+            return_value=2.5,
+        ) as mock_uniform:
+            with unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
+                capture_sleep,
+            ):
+                with self.assertRaises(asyncio.CancelledError):
+                    await loop._run_poller(('tenant', 'backend'), Mock())
+
+        assert intervals == pytest.approx([2.5])
+        mock_uniform.assert_called_once_with(0, 5.0)
+
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.init_async_db')
+    @unittest.mock.patch('wazo_chatd.plugins.connectors.runner.BusPublisher')
+    async def test_spawn_jitter_happens_even_when_step_jitter_disabled(
+        self, mock_bus: Mock, mock_init_db: Mock
+    ) -> None:
+        mock_init_db.return_value = (AsyncMock(), _mock_session_factory())
+        mock_bus.from_config.return_value = Mock()
+        config = _make_config()
+        config['delivery'] = {
+            **config['delivery'],
+            'poll_interval_min': 5,
+            'poll_interval_max': 5,
+            'poll_jitter_ratio': 0,
+        }
+        loop = DeliveryRunner(config, Mock(), Mock())
         intervals: list[float] = []
 
         async def fake_scan(*_args: object) -> bool:

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -643,7 +643,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == [42.0]
+        assert intervals == pytest.approx([42.0])
 
     async def test_rate_limit_event_raises_floor_for_subsequent_polls(
         self,
@@ -675,7 +675,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals[0] == 10.0
+        assert intervals[0] == pytest.approx(10.0)
         assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
         assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
 
@@ -702,7 +702,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == [3600.0]
+        assert intervals == pytest.approx([3600.0])
 
 
 class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
@@ -781,7 +781,7 @@ class TestDeliveryRunnerPollerJitter(unittest.IsolatedAsyncioTestCase):
                 with self.assertRaises(asyncio.CancelledError):
                     await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == [2.5]
+        assert intervals == pytest.approx([2.5])
         mock_uniform.assert_called_once_with(0, 5.0)
 
 

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -572,7 +572,7 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals == [4, 8, 8, 8, 8]
+        assert intervals == [2, 4, 8, 8, 8]
 
     async def test_non_empty_cycle_snaps_to_min(self) -> None:
         loop = self._make_loop()
@@ -600,8 +600,8 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await loop._run_poller(('tenant', 'backend'), Mock())
 
-        assert intervals[0] == 4
-        assert intervals[1] == 8
+        assert intervals[0] == 2
+        assert intervals[1] == 4
         assert intervals[2] == 1
         assert intervals[3] == 2
 

--- a/wazo_chatd/plugins/connectors/tests/test_runner.py
+++ b/wazo_chatd/plugins/connectors/tests/test_runner.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import time
 import unittest
 import unittest.mock
+from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -61,6 +63,90 @@ def _mock_store() -> Mock:
     store.items.return_value = []
     store.wait_populated = AsyncMock()
     return store
+
+
+async def _no_work(*_args: object) -> bool:
+    return False
+
+
+def _yields_on_call(target: int) -> Callable[..., Awaitable[bool]]:
+    state = {'n': 0}
+
+    async def scan(*_args: object) -> bool:
+        state['n'] += 1
+        return state['n'] == target
+
+    return scan
+
+
+def _raises_then_yields(
+    exc: BaseException,
+) -> Callable[..., Awaitable[bool]]:
+    state = {'n': 0}
+
+    async def scan(*_args: object) -> bool:
+        state['n'] += 1
+        if state['n'] == 1:
+            raise exc
+        return True
+
+    return scan
+
+
+def _always_raises(
+    exc_factory: Callable[[], BaseException],
+) -> Callable[..., Awaitable[bool]]:
+    async def scan(*_args: object) -> bool:
+        raise exc_factory()
+
+    return scan
+
+
+async def _run_poller_capturing_sleeps(
+    loop: DeliveryRunner,
+    *,
+    scan: Callable[..., Awaitable[bool]],
+    track: Callable[..., Awaitable[bool]] = _no_work,
+    max_intervals: int,
+    fake_clock: bool = False,
+) -> list[float]:
+    intervals: list[float] = []
+    fake_now = [0.0]
+
+    loop._scan_inbound = scan  # type: ignore[method-assign,assignment]
+    loop._track_outbound = track  # type: ignore[method-assign,assignment]
+
+    async def capture_sleep(d: float) -> None:
+        intervals.append(d)
+        if fake_clock:
+            fake_now[0] += d
+        if len(intervals) >= max_intervals:
+            raise asyncio.CancelledError()
+
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(
+            unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.runner.random.uniform',
+                return_value=0,
+            )
+        )
+        stack.enter_context(
+            unittest.mock.patch(
+                'wazo_chatd.plugins.connectors.runner.asyncio.sleep',
+                capture_sleep,
+            )
+        )
+        if fake_clock:
+            stack.enter_context(
+                unittest.mock.patch(
+                    'wazo_chatd.plugins.connectors.runner.monotonic',
+                    lambda: fake_now[0],
+                )
+            )
+        with contextlib.suppress(asyncio.CancelledError):
+            await loop._run_poller(('tenant', 'backend'), Mock())
+
+    return intervals
 
 
 class TestRunnerEntrypoint(unittest.IsolatedAsyncioTestCase):
@@ -555,34 +641,10 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
     async def test_empty_cycles_grow_interval_toward_poll_max(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
-        fake_now = [0.0]
 
-        async def fake_scan(*_args: object) -> bool:
-            return False
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            fake_now[0] += d
-            if len(intervals) >= 6:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.monotonic',
-            lambda: fake_now[0],
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop, scan=_no_work, max_intervals=6, fake_clock=True
+        )
 
         _, *step_sleeps = intervals
         assert all(loop._poll_min <= i <= loop._poll_max for i in step_sleeps)
@@ -592,36 +654,13 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
     async def test_yield_pulls_interval_back_toward_poll_min(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
-        fake_now = [0.0]
-        call_count = {'n': 0}
 
-        async def fake_scan(*_args: object) -> bool:
-            call_count['n'] += 1
-            return call_count['n'] == 3
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            fake_now[0] += d
-            if len(intervals) >= 5:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.monotonic',
-            lambda: fake_now[0],
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_yields_on_call(3),
+            max_intervals=5,
+            fake_clock=True,
+        )
 
         _, *step_sleeps = intervals
         assert step_sleeps[1] > step_sleeps[0]
@@ -631,29 +670,14 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
     async def test_rate_limited_uses_provider_retry_after(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
 
-        async def fake_scan(*_args: object) -> bool:
-            raise ConnectorRateLimited('rate limited', retry_after=42.0)
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            if len(intervals) >= 2:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_always_raises(
+                lambda: ConnectorRateLimited('rate limited', retry_after=42.0)
+            ),
+            max_intervals=2,
+        )
 
         assert intervals[1] == pytest.approx(42.0)
 
@@ -661,33 +685,14 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
         self,
     ) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
-        call_count = {'n': 0}
 
-        async def fake_scan(*_args: object) -> bool:
-            call_count['n'] += 1
-            if call_count['n'] == 1:
-                raise ConnectorRateLimited('throttle', retry_after=10.0)
-            return True
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            if len(intervals) >= 4:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_raises_then_yields(
+                ConnectorRateLimited('throttle', retry_after=10.0)
+            ),
+            max_intervals=4,
+        )
 
         assert intervals[1] == pytest.approx(10.0)
         assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)
@@ -695,61 +700,25 @@ class TestDeliveryRunnerPollerBackoff(unittest.IsolatedAsyncioTestCase):
 
     async def test_rate_limited_caps_retry_after_at_max(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
 
-        async def fake_scan(*_args: object) -> bool:
-            raise ConnectorRateLimited('rate limited', retry_after=999_999.0)
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            if len(intervals) >= 2:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_always_raises(
+                lambda: ConnectorRateLimited('rate limited', retry_after=999_999.0)
+            ),
+            max_intervals=2,
+        )
 
         assert intervals[1] == pytest.approx(3600.0)
 
     async def test_unexpected_error_raises_floor_for_subsequent_polls(self) -> None:
         loop = self._make_loop()
-        intervals: list[float] = []
-        call_count = {'n': 0}
 
-        async def fake_scan(*_args: object) -> bool:
-            call_count['n'] += 1
-            if call_count['n'] == 1:
-                raise RuntimeError('boom')
-            return True
-
-        async def fake_track(*_args: object) -> bool:
-            return False
-
-        loop._scan_inbound = fake_scan  # type: ignore[method-assign,assignment]
-        loop._track_outbound = fake_track  # type: ignore[method-assign,assignment]
-
-        async def capture_sleep(d: float) -> None:
-            intervals.append(d)
-            if len(intervals) >= 3:
-                raise asyncio.CancelledError()
-
-        with unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.random.uniform', return_value=0
-        ), unittest.mock.patch(
-            'wazo_chatd.plugins.connectors.runner.asyncio.sleep', capture_sleep
-        ):
-            with self.assertRaises(asyncio.CancelledError):
-                await loop._run_poller(('tenant', 'backend'), Mock())
+        intervals = await _run_poller_capturing_sleeps(
+            loop,
+            scan=_raises_then_yields(RuntimeError('boom')),
+            max_intervals=3,
+        )
 
         assert intervals[1] == pytest.approx(loop._rate_limit_floor, abs=0.01)
         assert intervals[2] == pytest.approx(loop._rate_limit_floor, abs=0.01)


### PR DESCRIPTION
## Summary

Make polling-mode connector deployments (security-constrained, no inbound webhooks) feel closer to webhook-responsive without hammering the upstream provider when idle.

- **Adaptive cadence (`PollerCadence`)** — forward-Euler controller that speeds up toward `poll_min` when a poll cycle does work (`scan_inbound` finds messages or `track_outbound` applies status updates), and decays toward `poll_max` when idle. Speed-up and slow-down time-constants are independent (`tau_speedup` / `tau_slowdown`).
- **Sticky rate-limit floor** — after a `ConnectorRateLimited`, the cadence's effective minimum is raised to `rate_limit_floor` for `rate_limit_window` seconds, so a yield doesn't immediately pull the interval back into the throttled zone.
- **Herd protection** — initial spawn jitter (random `[0, poll_min)` before the first poll) plus per-step jitter (`±jitter_ratio` of `next_interval`) to desync pollers across tenants/backends and avoid synchronized request bursts.
- **Cold-start fix** — interval is seeded at `poll_min` rather than `poll_default`, so a freshly spawned poller picks up activity quickly instead of starting in slow-decay mode.
- **Refactor (last commit)** — rename `CadenceController` → `PollerCadence`, `step(yielded, dt)` → `step(did_work=…)`, with the cadence reading its own clock so the runner no longer needs `prev_dt` bookkeeping.

## Test plan

- [x] Unit tests for cadence math (cold-start, yield/empty steps, stability, rate-limit floor, elapsed-time tracking)
- [x] Runner integration tests for empty-cycle growth, yield pull-back to `poll_min`, rate-limit `retry_after` honoring + capping, jitter variance at fixed interval
- [x] Pre-commit clean (black, isort, flake8, mypy strict)
- [ ] Manual smoke test in a polling-mode deployment (verify desync across multiple tenants and convergence to `poll_max` when idle)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the connector polling loop timing and rate-limit handling, which can affect delivery latency and upstream provider load if mis-tuned.
> 
> **Overview**
> Replaces the connector poller’s fixed/exponential backoff (`poll_interval_default` + doubling) with an **adaptive cadence controller** (`PollerCadence`) that moves polling toward `poll_interval_min` when work is found and toward `poll_interval_max` when idle.
> 
> Adds **herd protection** via initial spawn jitter and per-interval jitter, plus a **sticky rate-limit/error penalty** that temporarily raises the effective minimum poll interval (`poll_rate_limit_floor` for `poll_rate_limit_window`) after rate limits or unexpected errors. Updates default config keys accordingly and adds focused unit/integration tests for cadence math, jitter, and rate-limit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b473cf769d3b20258fef736cc10282a51efdd37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->