### PR TITLE
connector inbound: skip external participants in message_created

### DIFF
--- a/integration_tests/suite/test_connector_bus_events.py
+++ b/integration_tests/suite/test_connector_bus_events.py
@@ -19,6 +19,7 @@ from .helpers.base import (
 EXTERNAL_IDENTITY = 'test:+15559876'
 SENDER_IDENTITY = 'test:+15551234'
 RECIPIENT_UUID = uuid.uuid4()
+USER_UUID_RECIPIENT = uuid.uuid4()
 
 
 @use_asset('connectors')
@@ -90,6 +91,8 @@ class TestInboundMessageEvent(ConnectorIntegrationTest):
         )
         assert response.status_code == 204
 
+        recipient_header = f'user_uuid:{TOKEN_USER_UUID}'
+
         def event_received():
             events = accumulator.accumulate(with_headers=True)
             assert len(events) >= 1
@@ -100,6 +103,23 @@ class TestInboundMessageEvent(ConnectorIntegrationTest):
             assert delivery['backend'] == 'test'
 
         until.assert_(event_received, timeout=5, interval=0.1)
+
+        events = accumulator.accumulate(with_headers=True)
+        inbound_events = [
+            e
+            for e in events
+            if e['message']['data'].get('content') == 'Inbound event test'
+        ]
+        user_uuid_headers = sorted(
+            h
+            for e in inbound_events
+            for h in e['headers']
+            if h.startswith('user_uuid:') and e['headers'][h] is True
+        )
+        assert user_uuid_headers == [recipient_header], (
+            f'expected exactly one event for recipient {TOKEN_USER_UUID}, got '
+            f'user_uuid headers: {user_uuid_headers}'
+        )
 
 
 @use_asset('connectors')
@@ -190,3 +210,119 @@ class TestExternalAuthCacheInvalidation(ConnectorIntegrationTest):
             assert test_connector['configured'] is False
 
         until.assert_(cache_invalidated, timeout=5, interval=0.1)
+
+
+@use_asset('connectors')
+class TestEchoConfirmationNotifiesRecipient(ConnectorIntegrationTest):
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_RECIPIENT)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_RECIPIENT,
+        backend='test',
+        identity=EXTERNAL_IDENTITY,
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'uuid': str(USER_UUID_RECIPIENT)},
+        ],
+    )
+    def test_echo_path_publishes_room_message_created_for_recipient(
+        self, user_a, user_b, identity_a, identity_b, room
+    ):
+        accumulator = self.bus.accumulator(
+            headers={'name': 'chatd_user_room_message_created'}
+        )
+
+        self.connector_mock.reset()
+        self.connector_mock.set_config(
+            send_behavior='succeed', external_id='ext-echo-event-001'
+        )
+
+        room_uuid = room['uuid']
+        port = self.asset_cls.service_port(9304, 'chatd')
+
+        self.chatd.rooms.create_message_from_user(
+            room_uuid,
+            {
+                'content': 'echo notify test',
+                'sender_identity_uuid': str(identity_a.uuid),
+            },
+        )
+
+        def outbound_sent():
+            sent = self.connector_mock.get_sent_messages()
+            assert any(m['body'] == 'echo notify test' for m in sent)
+
+        until.assert_(outbound_sent, timeout=5, interval=0.1)
+
+        response = requests.post(
+            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
+            json={
+                'from': SENDER_IDENTITY,
+                'to': EXTERNAL_IDENTITY,
+                'body': 'echo notify test',
+                'message_id': 'ext-echo-notify-001',
+            },
+            headers={'X-Test-Connector': 'true'},
+        )
+        assert response.status_code == 204
+
+        sender_header = f'user_uuid:{TOKEN_USER_UUID}'
+        recipient_header = f'user_uuid:{USER_UUID_RECIPIENT}'
+
+        def recipient_received_event():
+            events = accumulator.accumulate(with_headers=True)
+            matching = [
+                e
+                for e in events
+                if e['message']['data'].get('content') == 'echo notify test'
+            ]
+            recipient_events = [
+                e for e in matching if e['headers'].get(recipient_header) is True
+            ]
+            assert len(recipient_events) >= 1, (
+                f'recipient {USER_UUID_RECIPIENT} got no '
+                f'chatd_user_room_message_created (echo path); '
+                f'matching headers: {[e["headers"] for e in matching]}'
+            )
+
+        until.assert_(recipient_received_event, timeout=5, interval=0.1)
+
+        events = accumulator.accumulate(with_headers=True)
+        echo_matches = [
+            e
+            for e in events
+            if e['message']['data'].get('content') == 'echo notify test'
+        ]
+        recipients = [
+            h
+            for e in echo_matches
+            for h in e['headers']
+            if h.startswith('user_uuid:') and e['headers'][h] is True
+        ]
+        assert (
+            recipients.count(sender_header) == 1
+        ), f'sender event count != 1: {recipients}'
+        assert (
+            recipients.count(recipient_header) == 1
+        ), f'recipient event count != 1: {recipients}'
+        assert set(recipients) == {
+            sender_header,
+            recipient_header,
+        }, f'unexpected user_uuid header in echo events: {recipients}'
+
+        recipient_event = next(
+            e for e in echo_matches if e['headers'].get(recipient_header) is True
+        )
+        recipient_data_user_uuid = recipient_event['message']['data'].get('user_uuid')
+        assert recipient_data_user_uuid == str(TOKEN_USER_UUID), (
+            'data.user_uuid must be the message sender so webhookd does not '
+            f'suppress the push to recipient {USER_UUID_RECIPIENT}; '
+            f'got {recipient_data_user_uuid}'
+        )

--- a/wazo_chatd/plugins/connectors/notifier.py
+++ b/wazo_chatd/plugins/connectors/notifier.py
@@ -76,6 +76,8 @@ class AsyncNotifier:
     async def message_created(self, room: Room, message: RoomMessage) -> None:
         message_data = self._build_message_payload(message)
         for user in room.users:
+            if user.identity:
+                continue
             event = UserRoomMessageCreatedEvent(
                 message_data, room.uuid, room.tenant_uuid, user.uuid
             )

--- a/wazo_chatd/plugins/connectors/tests/test_notifier.py
+++ b/wazo_chatd/plugins/connectors/tests/test_notifier.py
@@ -118,17 +118,35 @@ class TestAsyncNotifierMessageCreated(unittest.IsolatedAsyncioTestCase):
         room = Mock()
         room.uuid = 'room-uuid'
         room.tenant_uuid = 'tenant-uuid'
-        room.users = [Mock(uuid='user-1'), Mock(uuid='user-2')]
+        room.users = [
+            Mock(uuid='user-1', identity=None),
+            Mock(uuid='user-2', identity=None),
+        ]
 
         await self.notifier.message_created(room, self._make_message())
 
         assert self.bus.publish.call_count == 2
 
+    async def test_skips_external_participant(self) -> None:
+        room = Mock()
+        room.uuid = 'room-uuid'
+        room.tenant_uuid = 'tenant-uuid'
+        room.users = [
+            Mock(uuid='wazo-user', identity=None),
+            Mock(uuid='external-uuid5', identity='+15551234'),
+        ]
+
+        await self.notifier.message_created(room, self._make_message())
+
+        assert self.bus.publish.call_count == 1
+        event = self.bus.publish.call_args[0][0]
+        assert event.user_uuid == 'wazo-user'
+
     async def test_publishes_correct_event_type(self) -> None:
         room = Mock()
         room.uuid = 'room-uuid'
         room.tenant_uuid = 'tenant-uuid'
-        room.users = [Mock(uuid='user-1')]
+        room.users = [Mock(uuid='user-1', identity=None)]
 
         await self.notifier.message_created(room, self._make_message())
 
@@ -139,7 +157,7 @@ class TestAsyncNotifierMessageCreated(unittest.IsolatedAsyncioTestCase):
         room = Mock()
         room.uuid = 'room-uuid'
         room.tenant_uuid = 'tenant-uuid'
-        room.users = [Mock(uuid='user-1')]
+        room.users = [Mock(uuid='user-1', identity=None)]
 
         await self.notifier.message_created(room, self._make_message())
 


### PR DESCRIPTION
## Summary
- Filter external (uuid5) participants out of `AsyncNotifier.message_created` so we stop publishing `chatd_user_room_message_created` events to user_uuids that nothing consumes (webhookd/websocketd both bind by `user_uuid:<uuid>`)
- Add an integration test asserting a fresh external→Wazo inbound publishes exactly one event (for the recipient), zero waste
- Add a regression test for the 2-internal-users SMS-echo path: confirms the delivery-confirmation branch (`_confirm_delivery` → `_notify_message_delivered`) still notifies the recipient with `data.user_uuid` set to the sender, so webhookd's "don't push your own message" gate doesn't suppress the recipient's mobile push

## Test plan
- [ ] `pytest integration_tests/suite/test_connector_bus_events.py integration_tests/suite/test_connector_webhook.py` — 22 passed
- [ ] `pytest wazo_chatd/plugins/connectors/tests/test_notifier.py` — 14 passed (including new `test_skips_external_participant`)
- [ ] `pre-commit run --files <changed>` — all hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking REST surface, tenant/auth rules on identity CRUD, cache invalidation on bus events, and changed message-created event recipients affect integrations and mobile push behavior.
> 
> **Overview**
> This release reshapes connector and identity management around **tenant-scoped `/identities`** and new **`GET /connectors`** / **`GET /connectors/{backend}/identities`** APIs, while **removing** the old **`/users/{user_uuid}/identities`** CRUD routes (**`/users/me/identities`** stays). Identity listing gains **pagination, search, sort, and filters** with **`filtered` vs `total`** counts; create/update schemas add **`user_uuid` in the body**, stricter **`extra`** validation, and **cross-tenant user checks** on create.
> 
> **`AsyncNotifier.message_created`** now **skips room participants that only have an external `identity`**, so **`chatd_user_room_message_created`** is not published for synthetic uuid5 users. Integration tests cover **single-recipient inbound bus headers** and the **SMS echo / delivery-confirmation** path (recipient still gets an event with **`data.user_uuid`** as the sender).
> 
> Connectors gain **`list_backend_identities`** (with **501/502** API errors), **auth bus handlers** that **invalidate per-tenant backend cache** and **resync pollers/listeners**, and config rename **`backend_cache_ttl`**. DAO/service layers consolidate on **`list_` / `count`** with tenant-scoped **bound-identity** lookups; tests and fixtures move to the new client API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6625932541a6e32289c5ccf78e1e90d9f9e6fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->