### PR TITLE
connectors: render cross-tenant inbound sender as external contact

### DIFF
--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -484,6 +484,27 @@ class ConnectorIntegrationTest(_BaseIntegrationTest):
         super().reset_clients()
         cls.connector_mock = cls.asset_cls.make_connector_mock()
 
+    def post_inbound(
+        self,
+        payload: dict,
+        backend: str | None = None,
+        headers: dict | None = None,
+    ) -> requests.Response:
+        port = self.asset_cls.service_port(9304, 'chatd')
+
+        path = '/1.0/connectors/incoming'
+        if backend is not None:
+            path = f'{path}/{backend}'
+
+        if headers is None:
+            headers = {'X-Test-Connector': 'true'}
+
+        return requests.post(
+            f'http://127.0.0.1:{port}{path}',
+            json=payload,
+            headers=headers,
+        )
+
 
 class PollingConnectorIntegrationTest(ConnectorIntegrationTest):
     asset_cls = PollingConnectorAssetLaunchingTestCase

--- a/integration_tests/suite/test_connector_bus_events.py
+++ b/integration_tests/suite/test_connector_bus_events.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import uuid
 
-import requests
 from wazo_test_helpers import until
 
 from .helpers import fixtures
@@ -77,16 +76,13 @@ class TestInboundMessageEvent(ConnectorIntegrationTest):
             headers={'name': 'chatd_user_room_message_created'}
         )
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'from': EXTERNAL_IDENTITY,
                 'to': SENDER_IDENTITY,
                 'body': 'Inbound event test',
                 'message_id': f'ext-bus-{uuid.uuid4()}',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -144,14 +140,11 @@ class TestDeliveryStatusEvent(ConnectorIntegrationTest):
 
         until.assert_(accepted_event_received, timeout=5, interval=0.1)
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        self.post_inbound(
+            {
                 'external_id': 'ext-bus-status-001',
                 'status': 'delivered',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
 
         def delivered_event_received():

--- a/integration_tests/suite/test_connector_bus_events.py
+++ b/integration_tests/suite/test_connector_bus_events.py
@@ -7,6 +7,8 @@ import uuid
 
 from wazo_test_helpers import until
 
+from wazo_chatd.plugin_helpers.tenant import make_uuid5
+
 from .helpers import fixtures
 from .helpers.base import (
     TOKEN_TENANT_UUID,
@@ -18,6 +20,8 @@ from .helpers.base import (
 EXTERNAL_IDENTITY = 'test:+15559876'
 SENDER_IDENTITY = 'test:+15551234'
 RECIPIENT_UUID = uuid.uuid4()
+OTHER_TENANT_UUID = uuid.uuid4()
+FOREIGN_USER_UUID = uuid.uuid4()
 
 
 @use_asset('connectors')
@@ -96,6 +100,59 @@ class TestInboundMessageEvent(ConnectorIntegrationTest):
             assert delivery['backend'] == 'test'
 
         until.assert_(event_received, timeout=5, interval=0.1)
+
+    @fixtures.db.tenant(uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=FOREIGN_USER_UUID, tenant_uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity=SENDER_IDENTITY,
+    )
+    @fixtures.db.user_identity(
+        user_uuid=FOREIGN_USER_UUID,
+        tenant_uuid=OTHER_TENANT_UUID,
+        backend='test',
+        identity=EXTERNAL_IDENTITY,
+    )
+    def test_cross_tenant_inbound_event_targets_synthetic_sender(
+        self, foreign_tenant, recipient, sender, recipient_identity, sender_identity
+    ):
+        accumulator = self.bus.accumulator(
+            headers={'name': 'chatd_user_room_message_created'}
+        )
+
+        response = self.post_inbound(
+            {
+                'from': EXTERNAL_IDENTITY,
+                'to': SENDER_IDENTITY,
+                'body': 'Cross-tenant event test',
+                'message_id': f'ext-bus-cross-{uuid.uuid4()}',
+            }
+        )
+        assert response.status_code == 204
+
+        synthetic_uuid = str(make_uuid5(str(TOKEN_TENANT_UUID), EXTERNAL_IDENTITY))
+
+        def event_targets_external_sender():
+            events = accumulator.accumulate(with_headers=True)
+            relevant = [
+                e
+                for e in events
+                if e['message']['data']['content'] == 'Cross-tenant event test'
+            ]
+            assert relevant
+            targeted = {
+                key.split(':', 1)[1]
+                for event in relevant
+                for key in event['headers']
+                if key.startswith('user_uuid:')
+            }
+            assert synthetic_uuid in targeted
+            assert str(TOKEN_USER_UUID) in targeted
+            assert str(FOREIGN_USER_UUID) not in targeted
+
+        until.assert_(event_targets_external_sender, timeout=5, interval=0.1)
 
 
 @use_asset('connectors')

--- a/integration_tests/suite/test_connector_webhook.py
+++ b/integration_tests/suite/test_connector_webhook.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import time
 import uuid
 
-import requests
 from sqlalchemy import select
 from wazo_test_helpers import until
 
@@ -16,6 +15,7 @@ from wazo_chatd.database.models import (
     MessageMeta,
     RoomMessage,
 )
+from wazo_chatd.plugin_helpers.tenant import make_uuid5
 
 from .helpers import fixtures
 from .helpers.base import (
@@ -27,6 +27,7 @@ from .helpers.base import (
 
 USER_UUID_1 = uuid.uuid4()
 USER_UUID_2 = uuid.uuid4()
+OTHER_TENANT_UUID = uuid.uuid4()
 EXTERNAL_IDENTITY = 'test:+15559876'
 
 
@@ -47,12 +48,7 @@ class TestInboundWebhook(ConnectorIntegrationTest):
             'message_id': 'ext-msg-001',
         }
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json=webhook_data,
-            headers={'X-Test-Connector': 'true'},
-        )
+        response = self.post_inbound(webhook_data)
 
         assert response.status_code == 204
 
@@ -71,6 +67,59 @@ class TestInboundWebhook(ConnectorIntegrationTest):
 
         until.assert_(message_persisted, timeout=5, interval=0.1)
 
+    @fixtures.db.tenant(uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_2, tenant_uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_2,
+        tenant_uuid=OTHER_TENANT_UUID,
+        backend='test',
+        identity='test:+15559876',
+    )
+    def test_webhook_cross_tenant_sender_rendered_as_external(
+        self, foreign_tenant, recipient, sender, recipient_identity, sender_identity
+    ):
+
+        webhook_data = {
+            'from': 'test:+15559876',
+            'to': 'test:+15551234',
+            'body': 'Cross-tenant inbound',
+            'message_id': 'ext-msg-cross-tenant',
+        }
+
+        response = self.post_inbound(webhook_data)
+
+        assert response.status_code == 204
+
+        expected_uuid = str(make_uuid5(str(TOKEN_TENANT_UUID), 'test:+15559876'))
+
+        def room_rendered_with_external_sender():
+            messages = self.chatd.rooms.search_messages_from_user(
+                search='Cross-tenant inbound'
+            )['items']
+            assert messages
+            room_uuid = messages[0]['room']['uuid']
+
+            rooms = self.chatd.rooms.list_from_user()['items']
+            room = next((r for r in rooms if r['uuid'] == room_uuid), None)
+            assert room is not None
+            assert room['tenant_uuid'] == str(TOKEN_TENANT_UUID)
+
+            sender_participant = next(
+                u for u in room['users'] if u['uuid'] != str(TOKEN_USER_UUID)
+            )
+            assert sender_participant['identity'] == 'test:+15559876'
+            assert sender_participant['uuid'] == expected_uuid
+            assert sender_participant['uuid'] != str(USER_UUID_2)
+            assert sender_participant['tenant_uuid'] == str(TOKEN_TENANT_UUID)
+
+        until.assert_(room_rendered_with_external_sender, timeout=5, interval=0.1)
+
     @fixtures.db.user(uuid=USER_UUID_1)
     @fixtures.db.user_identity(
         user_uuid=USER_UUID_1,
@@ -86,12 +135,7 @@ class TestInboundWebhook(ConnectorIntegrationTest):
             'message_id': 'ext-msg-002',
         }
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming/test',
-            json=webhook_data,
-            headers={'X-Test-Connector': 'true'},
-        )
+        response = self.post_inbound(webhook_data, backend='test')
 
         assert response.status_code == 204
 
@@ -104,11 +148,8 @@ class TestInboundWebhook(ConnectorIntegrationTest):
         until.assert_(message_persisted, timeout=5, interval=0.1)
 
     def test_webhook_unrecognized_payload_returns_400(self):
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={'body': 'hello'},
-            headers={'Content-Type': 'application/json'},
+        response = self.post_inbound(
+            {'body': 'hello'}, headers={'Content-Type': 'application/json'}
         )
 
         assert response.status_code == 400
@@ -129,13 +170,7 @@ class TestInboundWebhook(ConnectorIntegrationTest):
             'idempotency_key': 'unique-key-001',
         }
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json=webhook_data,
-            headers={'X-Test-Connector': 'true'},
-        )
+        response = self.post_inbound(webhook_data)
         assert response.status_code == 204
 
         def first_message_persisted():
@@ -148,11 +183,7 @@ class TestInboundWebhook(ConnectorIntegrationTest):
 
         until.assert_(first_message_persisted, timeout=5, interval=0.1)
 
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json=webhook_data,
-            headers={'X-Test-Connector': 'true'},
-        )
+        response = self.post_inbound(webhook_data)
         assert response.status_code == 204
 
         def still_one_message():
@@ -332,14 +363,11 @@ class TestStatusUpdate(ConnectorIntegrationTest):
 
         self._assert_delivery_status(message['uuid'], 'accepted')
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'external_id': 'ext-status-001',
                 'status': 'delivered',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -374,15 +402,12 @@ class TestStatusUpdate(ConnectorIntegrationTest):
 
         self._assert_delivery_status(message['uuid'], 'accepted')
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'external_id': 'ext-status-002',
                 'status': 'failed',
                 'error_code': '30003',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -426,14 +451,11 @@ class TestStatusUpdate(ConnectorIntegrationTest):
 
         self._assert_delivery_status(message['uuid'], 'accepted')
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'external_id': 'ext-status-003',
                 'status': 'queued',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -479,7 +501,6 @@ class TestMultiChannelRoom(ConnectorIntegrationTest):
         )
 
         room_uuid = room['uuid']
-        port = self.asset_cls.service_port(9304, 'chatd')
 
         self.chatd.rooms.create_message_from_user(
             room_uuid, {'content': 'Internal hello'}
@@ -496,15 +517,13 @@ class TestMultiChannelRoom(ConnectorIntegrationTest):
 
         until.assert_(mock_received_outbound, timeout=5, interval=0.1)
 
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'from': 'test:+15559876',
                 'to': 'test:+15551234',
                 'body': 'SMS reply from user B',
                 'message_id': 'ext-msg-multichannel',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -548,7 +567,6 @@ class TestMultiChannelRoom(ConnectorIntegrationTest):
         )
 
         room_uuid = room['uuid']
-        port = self.asset_cls.service_port(9304, 'chatd')
 
         self.chatd.rooms.create_message_from_user(
             room_uuid,
@@ -564,15 +582,13 @@ class TestMultiChannelRoom(ConnectorIntegrationTest):
 
         until.assert_(outbound_sent, timeout=5, interval=0.1)
 
-        response = requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={
+        response = self.post_inbound(
+            {
                 'from': 'test:+15551234',
                 'to': 'test:+15559876',
                 'body': 'Echo test message',
                 'message_id': 'ext-echo-inbound',
-            },
-            headers={'X-Test-Connector': 'true'},
+            }
         )
         assert response.status_code == 204
 
@@ -772,12 +788,7 @@ class TestMessageVisibility(ConnectorIntegrationTest):
 
         until.assert_(accepted, timeout=5, interval=0.1)
 
-        port = self.asset_cls.service_port(9304, 'chatd')
-        requests.post(
-            f'http://127.0.0.1:{port}/1.0/connectors/incoming',
-            json={'external_id': 'ext-vis-003', 'status': 'delivered'},
-            headers={'X-Test-Connector': 'true'},
-        )
+        self.post_inbound({'external_id': 'ext-vis-003', 'status': 'delivered'})
 
         chatd_b = self._make_user_b_client()
 

--- a/integration_tests/suite/test_connector_webhook.py
+++ b/integration_tests/suite/test_connector_webhook.py
@@ -602,6 +602,61 @@ class TestMultiChannelRoom(ConnectorIntegrationTest):
         echo_messages = [m for m in messages if m.content == 'Echo test message']
         assert len(echo_messages) == 1
 
+    @fixtures.db.tenant(uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user(uuid=TOKEN_USER_UUID)
+    @fixtures.db.user(uuid=USER_UUID_2, tenant_uuid=OTHER_TENANT_UUID)
+    @fixtures.db.user_identity(
+        user_uuid=TOKEN_USER_UUID,
+        backend='test',
+        identity='test:+15551234',
+    )
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_2,
+        tenant_uuid=OTHER_TENANT_UUID,
+        backend='test',
+        identity='test:+15559876',
+    )
+    @fixtures.http.room(
+        users=[
+            {'uuid': str(TOKEN_USER_UUID)},
+            {'identity': 'test:+15559876'},
+        ],
+    )
+    def test_outbound_then_inbound_cross_tenant_converge_on_one_room(
+        self,
+        foreign_tenant,
+        recipient,
+        sender,
+        recipient_identity,
+        sender_identity,
+        room,
+    ):
+        room_uuid = room['uuid']
+        expected_uuid = str(make_uuid5(str(TOKEN_TENANT_UUID), 'test:+15559876'))
+
+        sender_participant = next(
+            u for u in room['users'] if u['uuid'] != str(TOKEN_USER_UUID)
+        )
+        assert sender_participant['uuid'] == expected_uuid
+        assert sender_participant['uuid'] != str(USER_UUID_2)
+
+        response = self.post_inbound(
+            {
+                'from': 'test:+15559876',
+                'to': 'test:+15551234',
+                'body': 'Cross-tenant reply converges',
+                'message_id': 'ext-msg-cross-tenant-converge',
+            }
+        )
+        assert response.status_code == 204
+
+        def reply_lands_in_outbound_room():
+            messages = self.chatd.rooms.list_messages_from_user(room_uuid)['items']
+            contents = [m['content'] for m in messages]
+            assert 'Cross-tenant reply converges' in contents
+
+        until.assert_(reply_lands_in_outbound_room, timeout=5, interval=0.1)
+
 
 @use_asset('connectors')
 class TestMessageSchemaFields(ConnectorIntegrationTest):

--- a/integration_tests/suite/test_db_user_identity.py
+++ b/integration_tests/suite/test_db_user_identity.py
@@ -175,6 +175,41 @@ class TestUserIdentity(DBIntegrationTest):
         tenant_uuid=TENANT_1,
         backend='sms_backend',
         type_='sms',
+        identity='+15551111111',
+    )
+    @fixtures.db.user(uuid=USER_UUID_2, tenant_uuid=TENANT_2)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_2,
+        tenant_uuid=TENANT_2,
+        backend='sms_backend',
+        type_='sms',
+        identity='+15552222222',
+    )
+    def test_resolve_users_by_identities_scoped_to_tenant(
+        self, user_1, identity_1, user_2, identity_2
+    ):
+        scoped = self._dao.user_identity.resolve_users_by_identities(
+            [identity_1.identity, identity_2.identity], tenant_uuid=str(TENANT_1)
+        )
+        scoped_uuids = {str(u.uuid) for u in scoped.values()}
+        assert set(scoped) == {identity_1.identity}
+        assert str(USER_UUID_1) in scoped_uuids
+        assert str(USER_UUID_2) not in scoped_uuids
+
+        unscoped = self._dao.user_identity.resolve_users_by_identities(
+            [identity_1.identity, identity_2.identity]
+        )
+        unscoped_uuids = {str(u.uuid) for u in unscoped.values()}
+        assert set(unscoped) == {identity_1.identity, identity_2.identity}
+        assert str(USER_UUID_1) in unscoped_uuids
+        assert str(USER_UUID_2) in unscoped_uuids
+
+    @fixtures.db.user(uuid=USER_UUID_1, tenant_uuid=TENANT_1)
+    @fixtures.db.user_identity(
+        user_uuid=USER_UUID_1,
+        tenant_uuid=TENANT_1,
+        backend='sms_backend',
+        type_='sms',
         identity='+15551234567',
     )
     def test_find_tenant_by_identity(self, user, identity):

--- a/wazo_chatd/database/queries/user_identity.py
+++ b/wazo_chatd/database/queries/user_identity.py
@@ -194,12 +194,15 @@ class UserIdentityDAO:
     def resolve_users_by_identities(
         self,
         identities: Iterable[str],
+        tenant_uuid: str | None = None,
     ) -> dict[str, User]:
         statement = (
             select(UserIdentity)
             .options(selectinload(UserIdentity.user))
             .where(UserIdentity.identity.in_(list(identities)))
         )
+        if tenant_uuid is not None:
+            statement = statement.where(UserIdentity.tenant_uuid == tenant_uuid)
         return {
             str(r.identity): r.user
             for r in self.session.execute(statement).scalars().all()

--- a/wazo_chatd/plugins/connectors/executor.py
+++ b/wazo_chatd/plugins/connectors/executor.py
@@ -401,7 +401,7 @@ class DeliveryExecutor:
 
         sender_user = resolved.get(sender_identity)
         if sender_user and str(sender_user.tenant_uuid) != tenant_uuid:
-            logger.debug(
+            logger.info(
                 'Sender %s resolves to a user in tenant %s but recipient is in %s; '
                 'treating sender as external',
                 sender_identity,

--- a/wazo_chatd/plugins/connectors/executor.py
+++ b/wazo_chatd/plugins/connectors/executor.py
@@ -400,6 +400,16 @@ class DeliveryExecutor:
         tenant_uuid = str(recipient_user.tenant_uuid)
 
         sender_user = resolved.get(sender_identity)
+        if sender_user and str(sender_user.tenant_uuid) != tenant_uuid:
+            logger.debug(
+                'Sender %s resolves to a user in tenant %s but recipient is in %s; '
+                'treating sender as external',
+                sender_identity,
+                sender_user.tenant_uuid,
+                tenant_uuid,
+            )
+            sender_user = None
+
         sender_participant = RoomUser(
             uuid=(
                 sender_user.uuid

--- a/wazo_chatd/plugins/connectors/services.py
+++ b/wazo_chatd/plugins/connectors/services.py
@@ -80,8 +80,12 @@ class ConnectorService:
         self._dao.user_identity.ensure_tenant_and_user_exist(tenant_uuid, user_uuid)
         return tenant_uuid
 
-    def resolve_users_by_identities(self, identities: Iterable[str]) -> dict[str, User]:
-        return self._dao.user_identity.resolve_users_by_identities(identities)
+    def resolve_users_by_identities(
+        self, identities: Iterable[str], tenant_uuid: str | None = None
+    ) -> dict[str, User]:
+        return self._dao.user_identity.resolve_users_by_identities(
+            identities, tenant_uuid=tenant_uuid
+        )
 
     def resolve_room_participants(self, body: dict, tenant_uuid: str) -> None:
         users = body.get('users', [])
@@ -90,7 +94,7 @@ class ConnectorService:
             return
 
         identities = {u['identity'] for u in to_resolve}
-        resolved = self.resolve_users_by_identities(identities)
+        resolved = self.resolve_users_by_identities(identities, tenant_uuid=tenant_uuid)
 
         for user in to_resolve:
             identity = user['identity']

--- a/wazo_chatd/plugins/connectors/tests/test_executor.py
+++ b/wazo_chatd/plugins/connectors/tests/test_executor.py
@@ -17,6 +17,7 @@ from wazo_chatd.database.async_helpers import _current_session
 from wazo_chatd.database.delivery import DeliveryStatus
 from wazo_chatd.database.models import DeliveryRecord
 from wazo_chatd.exceptions import DuplicateExternalIdException
+from wazo_chatd.plugin_helpers.tenant import make_uuid5
 from wazo_chatd.plugins.connectors.exceptions import (
     ConnectorRateLimited,
     ConnectorSendError,
@@ -575,6 +576,32 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
             p for p in participants if str(p.uuid) == 'sender-wazo-uuid'
         ][0]
         assert sender_participant.identity is None
+
+    async def test_route_inbound_cross_tenant_sender_stays_external(self) -> None:
+        recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')
+        sender = Mock(uuid='sender-wazo-uuid', tenant_uuid='other-tenant-uuid')
+        room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
+        room.users = [Mock(uuid='recipient-uuid')]
+
+        inbound = _make_inbound()
+
+        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
+            return_value={'+15551234': recipient, '+15559876': sender}
+        )
+        self.executor._dao.room.find_room = AsyncMock(return_value=room)
+        self.executor._dao.room.create_room = AsyncMock()
+        self.executor._dao.room.find_matching_signature = AsyncMock(return_value=None)
+        self.executor._dao.room.add_message = AsyncMock()
+
+        await self.executor.route_inbound(inbound)
+
+        call_args = self.executor._dao.room.find_room.call_args
+        participants = call_args.args[1]
+        sender_participant = [p for p in participants if p.identity is not None][0]
+        assert sender_participant.identity == '+15559876'
+        assert sender_participant.tenant_uuid == 'tenant-uuid'
+        assert sender_participant.uuid == make_uuid5('tenant-uuid', '+15559876')
+        assert str(sender_participant.uuid) != 'sender-wazo-uuid'
 
     async def test_route_inbound_unresolved_sender_stays_external(self) -> None:
         recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')

--- a/wazo_chatd/plugins/connectors/tests/test_executor.py
+++ b/wazo_chatd/plugins/connectors/tests/test_executor.py
@@ -394,6 +394,15 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
     def tearDown(self) -> None:
         _current_session.reset(self.token)
 
+    def _stub_inbound(self, resolved: dict[str, Mock], room: Mock) -> None:
+        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
+            return_value=resolved
+        )
+        self.executor._dao.room.find_room = AsyncMock(return_value=room)
+        self.executor._dao.room.create_room = AsyncMock()
+        self.executor._dao.room.find_matching_signature = AsyncMock(return_value=None)
+        self.executor._dao.room.add_message = AsyncMock()
+
     async def test_route_inbound_dedup_skips_duplicate(self) -> None:
         inbound = _make_inbound(idempotency_key='existing-key')
 
@@ -558,20 +567,11 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
         room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
         room.users = [Mock(uuid='recipient-uuid'), Mock(uuid='sender-wazo-uuid')]
 
-        inbound = _make_inbound()
+        self._stub_inbound({'+15551234': recipient, '+15559876': sender}, room)
 
-        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
-            return_value={'+15551234': recipient, '+15559876': sender}
-        )
-        self.executor._dao.room.find_room = AsyncMock(return_value=room)
-        self.executor._dao.room.create_room = AsyncMock()
-        self.executor._dao.room.find_matching_signature = AsyncMock(return_value=None)
-        self.executor._dao.room.add_message = AsyncMock()
+        await self.executor.route_inbound(_make_inbound())
 
-        await self.executor.route_inbound(inbound)
-
-        call_args = self.executor._dao.room.find_room.call_args
-        participants = call_args.args[1]
+        participants = self.executor._dao.room.find_room.call_args.args[1]
         sender_participant = [
             p for p in participants if str(p.uuid) == 'sender-wazo-uuid'
         ][0]
@@ -583,20 +583,11 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
         room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
         room.users = [Mock(uuid='recipient-uuid')]
 
-        inbound = _make_inbound()
+        self._stub_inbound({'+15551234': recipient, '+15559876': sender}, room)
 
-        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
-            return_value={'+15551234': recipient, '+15559876': sender}
-        )
-        self.executor._dao.room.find_room = AsyncMock(return_value=room)
-        self.executor._dao.room.create_room = AsyncMock()
-        self.executor._dao.room.find_matching_signature = AsyncMock(return_value=None)
-        self.executor._dao.room.add_message = AsyncMock()
+        await self.executor.route_inbound(_make_inbound())
 
-        await self.executor.route_inbound(inbound)
-
-        call_args = self.executor._dao.room.find_room.call_args
-        participants = call_args.args[1]
+        participants = self.executor._dao.room.find_room.call_args.args[1]
         sender_participant = [p for p in participants if p.identity is not None][0]
         assert sender_participant.identity == '+15559876'
         assert sender_participant.tenant_uuid == 'tenant-uuid'
@@ -608,19 +599,11 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
         room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
         room.users = [Mock(uuid='recipient-uuid')]
 
-        inbound = _make_inbound()
+        self._stub_inbound({'+15551234': recipient}, room)
 
-        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
-            return_value={'+15551234': recipient}
-        )
-        self.executor._dao.room.find_room = AsyncMock(return_value=room)
-        self.executor._dao.room.create_room = AsyncMock()
-        self.executor._dao.room.add_message = AsyncMock()
+        await self.executor.route_inbound(_make_inbound())
 
-        await self.executor.route_inbound(inbound)
-
-        call_args = self.executor._dao.room.find_room.call_args
-        participants = call_args.args[1]
+        participants = self.executor._dao.room.find_room.call_args.args[1]
         sender_participant = [p for p in participants if p.identity is not None][0]
         assert sender_participant.identity == '+15559876'
 
@@ -670,17 +653,9 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
         room = Mock(uuid='room-uuid', tenant_uuid='tenant-uuid')
         room.users = [Mock(uuid='recipient-uuid'), Mock(uuid='sender-uuid')]
 
-        inbound = _make_inbound()
+        self._stub_inbound({'+15551234': recipient, '+15559876': sender}, room)
 
-        self.executor._dao.user_identity.resolve_users_by_identities = AsyncMock(
-            return_value={'+15551234': recipient, '+15559876': sender}
-        )
-        self.executor._dao.room.find_room = AsyncMock(return_value=room)
-        self.executor._dao.room.create_room = AsyncMock()
-        self.executor._dao.room.find_matching_signature = AsyncMock(return_value=None)
-        self.executor._dao.room.add_message = AsyncMock()
-
-        await self.executor.route_inbound(inbound)
+        await self.executor.route_inbound(_make_inbound())
 
         self.executor._dao.room.add_message.assert_awaited_once()
 

--- a/wazo_chatd/plugins/connectors/tests/test_executor.py
+++ b/wazo_chatd/plugins/connectors/tests/test_executor.py
@@ -593,6 +593,7 @@ class TestDeliveryExecutorRouteInbound(unittest.IsolatedAsyncioTestCase):
         assert sender_participant.tenant_uuid == 'tenant-uuid'
         assert sender_participant.uuid == make_uuid5('tenant-uuid', '+15559876')
         assert str(sender_participant.uuid) != 'sender-wazo-uuid'
+        self.executor._dao.room.find_matching_signature.assert_not_awaited()
 
     async def test_route_inbound_unresolved_sender_stays_external(self) -> None:
         recipient = Mock(uuid='recipient-uuid', tenant_uuid='tenant-uuid')

--- a/wazo_chatd/plugins/connectors/tests/test_user_identity.py
+++ b/wazo_chatd/plugins/connectors/tests/test_user_identity.py
@@ -290,3 +290,14 @@ class TestConnectorServiceResolveRoomParticipants(unittest.TestCase):
         service.resolve_room_participants(body, 'tenant-uuid')
 
         assert body == {}
+
+    def test_resolution_scoped_to_requester_tenant(self) -> None:
+        service = self._build_service()
+        service._dao.user_identity.resolve_users_by_identities.return_value = {}
+        body = {'users': [{'identity': '+15559876'}]}
+
+        service.resolve_room_participants(body, 'tenant-uuid')
+
+        service._dao.user_identity.resolve_users_by_identities.assert_called_once_with(
+            {'+15559876'}, tenant_uuid='tenant-uuid'
+        )


### PR DESCRIPTION
## Summary

When an inbound message's sender identity resolves to a wazo user in a **different tenant** than the recipient, `_resolve_inbound_room` built the room's sender participant with that foreign user's real `uuid` but the recipient's `tenant_uuid`. The resulting `(uuid, tenant_uuid)` pair is unresolvable in the recipient's tenant, so wazo-desktop silently drops the room from the chat list — even though the API still returns it (`GET /1.0/users/me/rooms`) and a `message_created` notification fires.

## Fix

Treat a cross-tenant resolved sender the same as an unresolved (truly external) one: synthesize the participant uuid from `uuid5(recipient_tenant, identity)` and keep the `identity` string set. This keeps the room in the recipient's tenant and renders the sender as an external SMS contact — consistent with how genuinely-external senders are already represented, no client-side change needed.

Side effect (intended): cross-tenant inbound is no longer eligible for outbound echo suppression, since `sender_user` is now `None`. This is correct — the outbound and inbound live in different tenants' rooms, so the signature lookup would never have matched.

## Tests

- **Unit** (`test_executor.py`): `test_route_inbound_cross_tenant_sender_stays_external` — asserts the participant gets the synthetic uuid + identity. Verified red-green (fails without the guard with `IndexError`).
- **Integration** (`test_connector_webhook.py`): `test_webhook_cross_tenant_sender_rendered_as_external` — end-to-end, asserts the room stays in the recipient's tenant and the sender renders as external (uuid5, not the foreign user uuid).
- Relocated inbound-POST plumbing into a `post_inbound` helper on `ConnectorIntegrationTest`.

All touched suites green: 18 `route_inbound` unit tests, 23 integration tests across `test_connector_webhook.py` + `test_connector_bus_events.py`.

## Notes

This is a render-layer remediation, not a root-cause fix — `resolve_users_by_identities` remains global/un-tenant-scoped. That's the appropriate scope for a connectors fix; the underlying identity-uniqueness concern is tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound room participant construction and tenant-scoped identity lookup, which affects multichannel messaging and room rendering but is well covered by new tests.
> 
> **Overview**
> Fixes inbound connector routing when a sender identity maps to a Wazo user in **another tenant** than the recipient. `_resolve_inbound_room` now drops that cross-tenant match and builds the sender like a true external contact: `uuid5(recipient_tenant, identity)` plus the identity string, so rooms stay in the recipient tenant and clients can render them.
> 
> **Room creation** identity resolution is tightened: `resolve_users_by_identities` accepts an optional `tenant_uuid` filter, and `resolve_room_participants` passes the requester’s tenant so foreign users are not bound when creating rooms from identities.
> 
> Integration coverage adds `post_inbound` on connector tests, cross-tenant webhook/bus/room-convergence scenarios, and a DAO test for tenant-scoped resolution. Unit tests cover the executor guard and tenant-scoped participant resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 108034d5842eb7a814dcff5ef273777aac738e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->