### PR TITLE
presences: fetch users via confd line_presence view

### DIFF
--- a/integration_tests/suite/test_presence_initialization.py
+++ b/integration_tests/suite/test_presence_initialization.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import random
@@ -34,7 +34,6 @@ USER_UUID_2 = uuid.uuid4()
 LINE_ID_1 = 6
 LINE_ID_2 = 42
 ENDPOINT_NAME = 'CUSTOM/name'
-FAKE_UUID_STR = str(uuid.uuid4())
 
 
 @use_asset('initialization')
@@ -109,17 +108,17 @@ class TestPresenceInitialization(InitIntegrationTest):
                     {
                         'id': line_1_created_id,
                         'name': line_1_created_name,
-                        'endpoint_sip': {'uuid': FAKE_UUID_STR},
+                        'protocol': 'sip',
                     },
                     {
                         'id': line_2_created_id,
                         'name': line_2_created_name,
-                        'endpoint_sccp': {'id': 1},
+                        'protocol': 'sccp',
                     },
                     {
                         'id': line_bugged_id,
                         'name': None,
-                        'endpoint_sip': {'uuid': FAKE_UUID_STR},
+                        'protocol': 'sip',
                     },
                 ],
                 'services': {'dnd': {'enabled': True}},
@@ -131,7 +130,7 @@ class TestPresenceInitialization(InitIntegrationTest):
                     {
                         'id': line_unchanged.id,
                         'name': ENDPOINT_NAME,
-                        'endpoint_custom': {'id': 1},
+                        'protocol': 'custom',
                     }
                 ],
                 'services': {'dnd': {'enabled': False}},

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -224,7 +224,7 @@ class Initiator:
         self.execute_post_hooks()
         self._in_progress.clear()
         self._is_initialized.set()
-        logger.debug('Initialized completed')
+        logger.info('Initialization completed')
 
     def initiate_tenants(self, tenants):
         tenants = {tenant['uuid'] for tenant in tenants}

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -98,11 +98,12 @@ def extract_endpoint_from_line(line):
     if not line['name']:
         return
 
-    if line.get('endpoint_sip'):
+    protocol = line.get('protocol')
+    if protocol == 'sip':
         return f'PJSIP/{line["name"]}'
-    elif line.get('endpoint_sccp'):
+    elif protocol == 'sccp':
         return f'SCCP/{line["name"]}'
-    elif line.get('endpoint_custom'):
+    elif protocol == 'custom':
         return line['name']
 
 
@@ -129,8 +130,8 @@ class Initiator:
     def in_progress(self):
         return self._in_progress.is_set()
 
-    def _paginate_proxy(self, callback, limit=1000):
-        callback = partial(callback, recurse=True, limit=limit)
+    def _paginate_proxy(self, callback, limit=1000, **list_params):
+        callback = partial(callback, recurse=True, limit=limit, **list_params)
         result = callback(limit=limit, offset=0)
         total = result['total']
         items = result['items']
@@ -172,7 +173,9 @@ class Initiator:
         self._milestone_tracker.mark(Resource.TENANT, Stage.FETCHED)
 
         logger.debug('Fetching users...')
-        users = self._paginate_proxy(self._confd.users.list, limit=1000)['items']
+        users = self._paginate_proxy(
+            self._confd.users.list, limit=1000, view='line_presence'
+        )['items']
         self._milestone_tracker.mark(Resource.USER, Stage.FETCHED)
 
         logger.debug('Fetching sesions...')

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -94,17 +94,33 @@ def extract_endpoint_from_channel(channel_name):
     return endpoint_name
 
 
+def _endpoint_name_for_protocol(protocol, line_name):
+    match protocol:
+        case 'sip':
+            return f'PJSIP/{line_name}'
+        case 'sccp':
+            return f'SCCP/{line_name}'
+        case 'custom':
+            return line_name
+        case _:
+            return None
+
+
+def extract_endpoint_from_line_presence_view(line):
+    if not line['name']:
+        return
+    return _endpoint_name_for_protocol(line.get('protocol'), line['name'])
+
+
 def extract_endpoint_from_line(line):
     if not line['name']:
         return
-
-    protocol = line.get('protocol')
-    if protocol == 'sip':
-        return f'PJSIP/{line["name"]}'
-    elif protocol == 'sccp':
-        return f'SCCP/{line["name"]}'
-    elif protocol == 'custom':
-        return line['name']
+    if line.get('endpoint_sip'):
+        return _endpoint_name_for_protocol('sip', line['name'])
+    if line.get('endpoint_sccp'):
+        return _endpoint_name_for_protocol('sccp', line['name'])
+    if line.get('endpoint_custom'):
+        return _endpoint_name_for_protocol('custom', line['name'])
 
 
 class Initiator:
@@ -309,7 +325,7 @@ class Initiator:
 
     def _add_missing_endpoints(self, users):
         lines = {
-            (line['id'], extract_endpoint_from_line(line))
+            (line['id'], extract_endpoint_from_line_presence_view(line))
             for user in users
             for line in user['lines']
         }
@@ -328,7 +344,7 @@ class Initiator:
 
     def _associate_line_endpoint(self, users):
         lines = {
-            (line['id'], extract_endpoint_from_line(line))
+            (line['id'], extract_endpoint_from_line_presence_view(line))
             for user in users
             for line in user['lines']
         }

--- a/wazo_chatd/plugins/presences/initiator_thread.py
+++ b/wazo_chatd/plugins/presences/initiator_thread.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import itertools
@@ -57,7 +57,7 @@ class InitiatorThread:
             self._initiate()
 
     def _initiate(self):
-        logger.debug('Starting presence initialization')
+        logger.info('Starting presence initialization')
         try:
             self._initiator.initiate()
         except requests.ReadTimeout as e:

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -1,3 +1,6 @@
+# Copyright 2025-2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from unittest import mock
 
 import pytest
@@ -6,7 +9,11 @@ from wazo_auth_client import Client as AuthClient
 from wazo_confd_client import Client as ConfdClient
 
 from wazo_chatd.database.queries import DAO
-from wazo_chatd.plugins.presences.initiator import Initiator
+from wazo_chatd.plugins.presences.initiator import (
+    Initiator,
+    extract_endpoint_from_line,
+    extract_endpoint_from_line_presence_view,
+)
 
 
 @pytest.fixture
@@ -18,6 +25,45 @@ def initiator():
         confd=mock.create_autospec(ConfdClient, instance=True),
         token_expiration=10,
     )
+
+
+@pytest.mark.parametrize(
+    'protocol, expected',
+    [
+        ('sip', 'PJSIP/line-name'),
+        ('sccp', 'SCCP/line-name'),
+        ('custom', 'line-name'),
+        ('unknown', None),
+    ],
+)
+def test_extract_endpoint_from_line_presence_view(protocol, expected):
+    line = {'name': 'line-name', 'protocol': protocol}
+    assert extract_endpoint_from_line_presence_view(line) == expected
+
+
+def test_extract_endpoint_from_line_presence_view_without_name():
+    assert extract_endpoint_from_line_presence_view({'name': None}) is None
+
+
+@pytest.mark.parametrize(
+    'endpoint_key, expected',
+    [
+        ('endpoint_sip', 'PJSIP/line-name'),
+        ('endpoint_sccp', 'SCCP/line-name'),
+        ('endpoint_custom', 'line-name'),
+    ],
+)
+def test_extract_endpoint_from_line(endpoint_key, expected):
+    line = {'name': 'line-name', endpoint_key: {'id': 1}}
+    assert extract_endpoint_from_line(line) == expected
+
+
+def test_extract_endpoint_from_line_without_name():
+    assert extract_endpoint_from_line({'name': None}) is None
+
+
+def test_extract_endpoint_from_line_without_endpoint():
+    assert extract_endpoint_from_line({'name': 'line-name'}) is None
 
 
 def test_paginate_proxy(initiator: Initiator):

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -91,3 +91,50 @@ def test_paginate_proxy(initiator: Initiator):
         'total': 10,
     }
     assert callback_mock.call_count == 5
+
+
+def test_paginate_proxy_forwards_list_params(initiator: Initiator):
+    def paginated_callback(recurse, limit, offset, view):
+        return {
+            'items': [{'id': offset + i} for i in range(1, limit + 1)],
+            'total': limit * 3,
+        }
+
+    callback_mock = mock.Mock(side_effect=paginated_callback)
+    initiator._paginate_proxy(callback_mock, limit=2, view='line_presence')
+
+    assert callback_mock.call_count == 3
+    for call in callback_mock.call_args_list:
+        assert call.kwargs['view'] == 'line_presence'
+        assert call.kwargs['recurse'] is True
+
+
+def test_initiate_fetches_users_with_line_presence_view(initiator: Initiator):
+    initiator._auth = mock.MagicMock()
+    initiator._amid = mock.MagicMock()
+    initiator._confd = mock.MagicMock()
+    initiator._auth.token.new.return_value = {'token': 'a-token'}
+
+    for method_name in (
+        'initiate_endpoints',
+        'initiate_tenants',
+        'initiate_users',
+        'initiate_sessions',
+        'initiate_refresh_tokens',
+        'initiate_channels',
+        'execute_post_hooks',
+    ):
+        setattr(initiator, method_name, mock.Mock())
+
+    with mock.patch.object(
+        initiator, '_paginate_proxy', return_value={'items': [], 'total': 0}
+    ) as paginate_proxy_mock:
+        initiator.initiate()
+
+    users_calls = [
+        call
+        for call in paginate_proxy_mock.call_args_list
+        if call.args and call.args[0] is initiator._confd.users.list
+    ]
+    assert len(users_calls) == 1
+    assert users_calls[0].kwargs.get('view') == 'line_presence'


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-confd/pull/568
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/347

## Summary

Fetch users via the lightweight confd `line_presence` view during presence initialization, instead of the default user view.

- `users.list` is called with `view='line_presence'` (threaded through `_paginate_proxy`).
- `extract_endpoint_from_line` resolves the endpoint type from the line `protocol` field (`sip`/`sccp`/`custom`), since the `line_presence` view returns lines as `{id, name, protocol}` rather than nested endpoint objects.

## Tests

`test_paginate_proxy` passes; pre-commit clean (flake8/black/isort/mypy).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the confd fetch contract during presence initialization (depends on the new line_presence view); wrong or incomplete view data could mis-associate lines and endpoints until upstream PRs land.
> 
> **Overview**
> Presence startup now loads users from confd with **`view='line_presence'`** instead of the full user payload, and **`_paginate_proxy`** forwards extra list kwargs on every paginated call so that view is applied consistently.
> 
> Because that view exposes lines as **`{id, name, protocol}`**, initialization maps **`sip` / `sccp` / `custom`** to Asterisk endpoint names via **`extract_endpoint_from_line_presence_view`** (shared **`_endpoint_name_for_protocol`** logic); the existing **`extract_endpoint_from_line`** path for nested endpoint objects is unchanged for bus events. Integration fixtures and unit tests were updated to match the new shape; init start/finish logs were bumped to **info**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3099ea2484c47d6461451fe8a15c3c821bced988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->