### PR TITLE
presences: reconcile presence-init writes in bulk

### DIFF
--- a/integration_tests/suite/test_db_endpoint.py
+++ b/integration_tests/suite/test_db_endpoint.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from typing import TYPE_CHECKING
@@ -76,6 +76,16 @@ class TestEndpoint(DBIntegrationTest):
 
         self._session.expire_all()
         assert_that(endpoint.state, equal_to(state))
+
+    def test_create_all_applies_model_default_state(self):
+        endpoint = Endpoint(name='PJSIP/bulk')
+        self._dao.endpoint.create_all([endpoint])
+
+        self._session.expire_all()
+        result = self._dao.endpoint.get_by(name='PJSIP/bulk')
+        assert result.state == 'unavailable'
+
+        self._dao.endpoint.delete_all()
 
     @fixtures.db.endpoint()
     @fixtures.db.endpoint()

--- a/integration_tests/suite/test_presence_initialization.py
+++ b/integration_tests/suite/test_presence_initialization.py
@@ -31,8 +31,12 @@ from .helpers.wait_strategy import ComponentsWaitStrategy, PresenceInitOkWaitStr
 TENANT_UUID = uuid.uuid4()
 USER_UUID_1 = uuid.uuid4()
 USER_UUID_2 = uuid.uuid4()
+USER_UUID_3 = uuid.uuid4()
+USER_UUID_4 = uuid.uuid4()
 LINE_ID_1 = 6
 LINE_ID_2 = 42
+LINE_ID_KEPT = 8001
+LINE_ID_DISSOCIATED = 8002
 ENDPOINT_NAME = 'CUSTOM/name'
 
 
@@ -328,6 +332,114 @@ class TestPresenceInitialization(InitIntegrationTest):
             contains_inanyorder(
                 has_properties(name=channel_unchanged_name, state='talking'),
                 has_properties(name=channel_created_name, state='holding'),
+            ),
+        )
+
+    @fixtures.db.tenant(uuid=TENANT_UUID)
+    @fixtures.db.user(uuid=USER_UUID_3, tenant_uuid=TENANT_UUID)
+    @fixtures.db.session(user_uuid=USER_UUID_3, mobile=False)
+    @fixtures.db.refresh_token(
+        client_id='mobile_toggled', user_uuid=USER_UUID_3, mobile=False
+    )
+    def test_initialization_updates_mobile_on_existing_session_and_token(
+        self, tenant, user, session, refresh_token
+    ):
+        self.auth.set_tenants(
+            {
+                'uuid': str(CHATD_TOKEN_TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+            {
+                'uuid': str(TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+        )
+        self.confd.set_users(
+            {
+                'uuid': str(USER_UUID_3),
+                'tenant_uuid': str(TENANT_UUID),
+                'lines': [],
+                'services': {'dnd': {'enabled': False}},
+            },
+        )
+        self.auth.set_sessions(
+            {
+                'uuid': str(session.uuid),
+                'user_uuid': str(USER_UUID_3),
+                'tenant_uuid': str(TENANT_UUID),
+                'mobile': True,
+            },
+        )
+        self.auth.set_refresh_tokens(
+            {
+                'client_id': refresh_token.client_id,
+                'user_uuid': str(USER_UUID_3),
+                'tenant_uuid': str(TENANT_UUID),
+                'mobile': True,
+            },
+        )
+
+        self.restart_chatd_service()
+        PresenceInitOkWaitStrategy().wait(self)
+        self._session.expire_all()
+
+        sessions = self._session.query(models.Session).all()
+        assert_that(
+            sessions,
+            contains_inanyorder(
+                has_properties(uuid=session.uuid, user_uuid=USER_UUID_3, mobile=True)
+            ),
+        )
+
+        refresh_tokens = self._session.query(models.RefreshToken).all()
+        assert_that(
+            refresh_tokens,
+            contains_inanyorder(
+                has_properties(
+                    client_id=refresh_token.client_id,
+                    user_uuid=USER_UUID_3,
+                    mobile=True,
+                )
+            ),
+        )
+
+    @fixtures.db.tenant(uuid=TENANT_UUID)
+    @fixtures.db.user(uuid=USER_UUID_4, tenant_uuid=TENANT_UUID)
+    @fixtures.db.line(id=LINE_ID_KEPT, user_uuid=USER_UUID_4)
+    @fixtures.db.line(id=LINE_ID_DISSOCIATED, user_uuid=USER_UUID_4)
+    def test_initialization_removes_line_dissociated_from_kept_user(
+        self, tenant, user, line_kept, line_dissociated
+    ):
+        self.auth.set_tenants(
+            {
+                'uuid': str(CHATD_TOKEN_TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+            {
+                'uuid': str(TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+        )
+        self.confd.set_users(
+            {
+                'uuid': str(USER_UUID_4),
+                'tenant_uuid': str(TENANT_UUID),
+                'lines': [
+                    {'id': LINE_ID_KEPT, 'name': 'kept', 'protocol': 'sip'},
+                ],
+                'services': {'dnd': {'enabled': False}},
+            },
+        )
+
+        self.restart_chatd_service()
+        PresenceInitOkWaitStrategy().wait(self)
+        self._session.expire_all()
+
+        lines = self._session.query(models.Line).all()
+        assert_that(
+            lines,
+            contains_inanyorder(
+                has_properties(id=LINE_ID_KEPT, user_uuid=USER_UUID_4),
             ),
         )
 

--- a/integration_tests/suite/test_presence_initialization.py
+++ b/integration_tests/suite/test_presence_initialization.py
@@ -35,8 +35,11 @@ USER_UUID_3 = uuid.uuid4()
 USER_UUID_4 = uuid.uuid4()
 LINE_ID_1 = 6
 LINE_ID_2 = 42
+USER_UUID_5 = uuid.uuid4()
+USER_UUID_6 = uuid.uuid4()
 LINE_ID_KEPT = 8001
 LINE_ID_DISSOCIATED = 8002
+LINE_ID_REASSIGNED = 8003
 ENDPOINT_NAME = 'CUSTOM/name'
 
 
@@ -440,6 +443,52 @@ class TestPresenceInitialization(InitIntegrationTest):
             lines,
             contains_inanyorder(
                 has_properties(id=LINE_ID_KEPT, user_uuid=USER_UUID_4),
+            ),
+        )
+
+    @fixtures.db.tenant(uuid=TENANT_UUID)
+    @fixtures.db.user(uuid=USER_UUID_5, tenant_uuid=TENANT_UUID)
+    @fixtures.db.user(uuid=USER_UUID_6, tenant_uuid=TENANT_UUID)
+    @fixtures.db.line(id=LINE_ID_REASSIGNED, user_uuid=USER_UUID_5)
+    def test_initialization_reassigns_line_to_different_user(
+        self, tenant, user_from, user_to, line
+    ):
+        self.auth.set_tenants(
+            {
+                'uuid': str(CHATD_TOKEN_TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+            {
+                'uuid': str(TENANT_UUID),
+                'parent_uuid': str(CHATD_TOKEN_TENANT_UUID),
+            },
+        )
+        self.confd.set_users(
+            {
+                'uuid': str(USER_UUID_5),
+                'tenant_uuid': str(TENANT_UUID),
+                'lines': [],
+                'services': {'dnd': {'enabled': False}},
+            },
+            {
+                'uuid': str(USER_UUID_6),
+                'tenant_uuid': str(TENANT_UUID),
+                'lines': [
+                    {'id': LINE_ID_REASSIGNED, 'name': 'reassigned', 'protocol': 'sip'},
+                ],
+                'services': {'dnd': {'enabled': False}},
+            },
+        )
+
+        self.restart_chatd_service()
+        PresenceInitOkWaitStrategy().wait(self)
+        self._session.expire_all()
+
+        lines = self._session.query(models.Line).all()
+        assert_that(
+            lines,
+            contains_inanyorder(
+                has_properties(id=LINE_ID_REASSIGNED, user_uuid=USER_UUID_6),
             ),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,21 @@ ignore_missing_imports = true
 module = ["*.tests.*", "integration_tests.*"]
 disable_error_code = ["method-assign", "attr-defined", "arg-type"]
 
+# Bulk write/read surface added by the presence-init reconcile refactor.
+# Keep it fully typed: any annotated def here must be complete.
+[[tool.mypy.overrides]]
+module = [
+    "wazo_chatd.database.helpers",
+    "wazo_chatd.database.queries.user",
+    "wazo_chatd.database.queries.line",
+    "wazo_chatd.database.queries.session",
+    "wazo_chatd.database.queries.refresh_token",
+    "wazo_chatd.database.queries.tenant",
+    "wazo_chatd.database.queries.endpoint",
+    "wazo_chatd.database.queries.channel",
+]
+disallow_incomplete_defs = true
+
 [tool.black]
 skip-string-normalization = true
 

--- a/wazo_chatd/database/helpers.py
+++ b/wazo_chatd/database/helpers.py
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from sqlalchemy import column, create_engine, update, values
-from sqlalchemy.orm import Query, scoped_session, sessionmaker
+from sqlalchemy.orm import Query
+from sqlalchemy.orm import Session as SASession
+from sqlalchemy.orm import scoped_session, sessionmaker
 
 if TYPE_CHECKING:
     # NOTE(clanglois): can be removed in sqlalchemy 2.0
@@ -20,7 +23,7 @@ Session = scoped_session(sessionmaker())
 BULK_BATCH_SIZE = 1000
 
 
-def _chunked(items, size):
+def _chunked(items: Sequence[T], size: int) -> Iterator[Sequence[T]]:
     for start in range(0, len(items), size):
         yield items[start : start + size]
 
@@ -43,13 +46,19 @@ def session_scope():
         Session.remove()
 
 
-def bulk_insert(session, instances):
+def bulk_insert(session: SASession, instances: Sequence[Any]) -> None:
     for chunk in _chunked(instances, BULK_BATCH_SIZE):
         session.bulk_save_objects(chunk)
     session.flush()
 
 
-def bulk_update(session, model, columns, rows, key_columns):
+def bulk_update(
+    session: SASession,
+    model: type[Any],
+    columns: Sequence[tuple[str, Any]],
+    rows: Sequence[tuple[Any, ...]],
+    key_columns: Sequence[str],
+) -> None:
     for chunk in _chunked(rows, BULK_BATCH_SIZE):
         source = values(
             *(column(name, type_) for name, type_ in columns),
@@ -69,7 +78,9 @@ def bulk_update(session, model, columns, rows, key_columns):
     session.flush()
 
 
-def bulk_delete(session, model, in_target, items):
+def bulk_delete(
+    session: SASession, model: type[Any], in_target: Any, items: Sequence[Any]
+) -> None:
     for chunk in _chunked(items, BULK_BATCH_SIZE):
         session.query(model).filter(in_target.in_(chunk)).delete(
             synchronize_session=False

--- a/wazo_chatd/database/helpers.py
+++ b/wazo_chatd/database/helpers.py
@@ -1,11 +1,11 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 from __future__ import annotations
 
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, TypeVar
 
-from sqlalchemy import create_engine
+from sqlalchemy import column, create_engine, update, values
 from sqlalchemy.orm import Query, scoped_session, sessionmaker
 
 if TYPE_CHECKING:
@@ -16,6 +16,13 @@ if TYPE_CHECKING:
 
 
 Session = scoped_session(sessionmaker())
+
+BULK_BATCH_SIZE = 1000
+
+
+def _chunked(items, size):
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
 
 
 def init_db(db_uri, echo=False, pool_size=16):
@@ -34,6 +41,40 @@ def session_scope():
         raise
     finally:
         Session.remove()
+
+
+def bulk_insert(session, instances):
+    for chunk in _chunked(instances, BULK_BATCH_SIZE):
+        session.bulk_save_objects(chunk)
+    session.flush()
+
+
+def bulk_update(session, model, columns, rows, key_columns):
+    for chunk in _chunked(rows, BULK_BATCH_SIZE):
+        source = values(
+            *(column(name, type_) for name, type_ in columns),
+            name='new_values',
+        ).data(chunk)
+
+        new_values = {
+            name: source.c[name] for name, _ in columns if name not in key_columns
+        }
+        query = update(model).values(new_values)
+
+        for key_column in key_columns:
+            query = query.where(getattr(model, key_column) == source.c[key_column])
+
+        query = query.execution_options(synchronize_session=False)
+        session.execute(query)
+    session.flush()
+
+
+def bulk_delete(session, model, in_target, items):
+    for chunk in _chunked(items, BULK_BATCH_SIZE):
+        session.query(model).filter(in_target.in_(chunk)).delete(
+            synchronize_session=False
+        )
+    session.flush()
 
 
 def get_query_main_entity(query: Query[T]) -> T:

--- a/wazo_chatd/database/queries/channel.py
+++ b/wazo_chatd/database/queries/channel.py
@@ -28,7 +28,7 @@ class ChannelDAO:
         self.session.add(channel)
         self.session.flush()
 
-    def create_all(self, channels):
+    def create_all(self, channels: list[Channel]) -> None:
         bulk_insert(self.session, channels)
 
     def delete_all(self):

--- a/wazo_chatd/database/queries/channel.py
+++ b/wazo_chatd/database/queries/channel.py
@@ -1,6 +1,7 @@
-# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from ..helpers import bulk_insert
 from ..models import Channel
 
 
@@ -26,6 +27,9 @@ class ChannelDAO:
     def update(self, channel):
         self.session.add(channel)
         self.session.flush()
+
+    def create_all(self, channels):
+        bulk_insert(self.session, channels)
 
     def delete_all(self):
         self.session.query(Channel).delete()

--- a/wazo_chatd/database/queries/endpoint.py
+++ b/wazo_chatd/database/queries/endpoint.py
@@ -1,7 +1,8 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ...exceptions import UnknownEndpointException
+from ..helpers import bulk_insert
 from ..models import Endpoint
 
 
@@ -17,6 +18,12 @@ class EndpointDAO:
         self.session.add(endpoint)
         self.session.flush()
         return endpoint
+
+    def create_all(self, endpoints):
+        bulk_insert(self.session, endpoints)
+
+    def list_names(self):
+        return {name for (name,) in self.session.query(Endpoint.name).all()}
 
     def find_by(self, **kwargs):
         return self._find_by(**kwargs)

--- a/wazo_chatd/database/queries/endpoint.py
+++ b/wazo_chatd/database/queries/endpoint.py
@@ -19,10 +19,10 @@ class EndpointDAO:
         self.session.flush()
         return endpoint
 
-    def create_all(self, endpoints):
+    def create_all(self, endpoints: list[Endpoint]) -> None:
         bulk_insert(self.session, endpoints)
 
-    def list_names(self):
+    def list_names(self) -> set[str]:
         return {name for (name,) in self.session.query(Endpoint.name).all()}
 
     def find_by(self, **kwargs):

--- a/wazo_chatd/database/queries/line.py
+++ b/wazo_chatd/database/queries/line.py
@@ -1,6 +1,9 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Sequence
+from typing import Any
+
 from sqlalchemy import Integer, Text
 from sqlalchemy.orm import joinedload
 
@@ -46,17 +49,17 @@ class LineDAO:
         self.session.add(line)
         self.session.flush()
 
-    def create_all(self, lines):
+    def create_all(self, lines: list[Line]) -> None:
         bulk_insert(self.session, lines)
 
-    def delete_by_ids(self, ids):
+    def delete_by_ids(self, ids: Sequence[int]) -> None:
         bulk_delete(self.session, Line, Line.id, ids)
 
     def associate_endpoint(self, line, endpoint):
         line.endpoint = endpoint
         self.session.flush()
 
-    def associate_endpoints(self, associations):
+    def associate_endpoints(self, associations: Sequence[dict[str, Any]]) -> None:
         bulk_update(
             self.session,
             Line,

--- a/wazo_chatd/database/queries/line.py
+++ b/wazo_chatd/database/queries/line.py
@@ -1,7 +1,11 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import Integer, Text
+from sqlalchemy.orm import joinedload
+
 from ...exceptions import UnknownLineException
+from ..helpers import bulk_delete, bulk_insert, bulk_update
 from ..models import Line
 
 
@@ -36,15 +40,30 @@ class LineDAO:
         return query.first()
 
     def list_(self):
-        return self.session.query(Line).all()
+        return self.session.query(Line).options(joinedload(Line.user)).all()
 
     def update(self, line):
         self.session.add(line)
         self.session.flush()
 
+    def create_all(self, lines):
+        bulk_insert(self.session, lines)
+
+    def delete_by_ids(self, ids):
+        bulk_delete(self.session, Line, Line.id, ids)
+
     def associate_endpoint(self, line, endpoint):
         line.endpoint = endpoint
         self.session.flush()
+
+    def associate_endpoints(self, associations):
+        bulk_update(
+            self.session,
+            Line,
+            columns=[('id', Integer), ('endpoint_name', Text)],
+            rows=[(a['id'], a['endpoint_name']) for a in associations],
+            key_columns=['id'],
+        )
 
     def dissociate_endpoint(self, line):
         line.endpoint = None

--- a/wazo_chatd/database/queries/refresh_token.py
+++ b/wazo_chatd/database/queries/refresh_token.py
@@ -1,9 +1,12 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import Boolean, Text, tuple_
 from sqlalchemy.orm import joinedload
+from sqlalchemy_utils import UUIDType
 
 from ...exceptions import UnknownRefreshTokenException
+from ..helpers import bulk_delete, bulk_insert, bulk_update
 from ..models import RefreshToken
 
 
@@ -44,3 +47,30 @@ class RefreshTokenDAO:
     def update(self, refresh_token):
         self.session.add(refresh_token)
         self.session.flush()
+
+    def create_all(self, refresh_tokens):
+        bulk_insert(self.session, refresh_tokens)
+
+    def delete_by_keys(self, keys):
+        bulk_delete(
+            self.session,
+            RefreshToken,
+            tuple_(RefreshToken.client_id, RefreshToken.user_uuid),
+            keys,
+        )
+
+    def update_all(self, refresh_tokens):
+        bulk_update(
+            self.session,
+            RefreshToken,
+            columns=[
+                ('client_id', Text),
+                ('user_uuid', UUIDType()),
+                ('mobile', Boolean),
+            ],
+            rows=[
+                (token['client_id'], token['user_uuid'], token['mobile'])
+                for token in refresh_tokens
+            ],
+            key_columns=['client_id', 'user_uuid'],
+        )

--- a/wazo_chatd/database/queries/refresh_token.py
+++ b/wazo_chatd/database/queries/refresh_token.py
@@ -1,6 +1,9 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Sequence
+from typing import Any
+
 from sqlalchemy import Boolean, Text, tuple_
 from sqlalchemy.orm import joinedload
 from sqlalchemy_utils import UUIDType
@@ -48,10 +51,10 @@ class RefreshTokenDAO:
         self.session.add(refresh_token)
         self.session.flush()
 
-    def create_all(self, refresh_tokens):
+    def create_all(self, refresh_tokens: list[RefreshToken]) -> None:
         bulk_insert(self.session, refresh_tokens)
 
-    def delete_by_keys(self, keys):
+    def delete_by_keys(self, keys: Sequence[tuple[str, str]]) -> None:
         bulk_delete(
             self.session,
             RefreshToken,
@@ -59,7 +62,7 @@ class RefreshTokenDAO:
             keys,
         )
 
-    def update_all(self, refresh_tokens):
+    def update_all(self, refresh_tokens: Sequence[dict[str, Any]]) -> None:
         bulk_update(
             self.session,
             RefreshToken,

--- a/wazo_chatd/database/queries/session.py
+++ b/wazo_chatd/database/queries/session.py
@@ -1,9 +1,12 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from sqlalchemy import Boolean
 from sqlalchemy.orm import joinedload
+from sqlalchemy_utils import UUIDType
 
 from ...exceptions import UnknownSessionException
+from ..helpers import bulk_delete, bulk_insert, bulk_update
 from ..models import Session
 
 
@@ -38,3 +41,18 @@ class SessionDAO:
     def update(self, session):
         self.session.add(session)
         self.session.flush()
+
+    def create_all(self, sessions):
+        bulk_insert(self.session, sessions)
+
+    def delete_by_uuids(self, uuids):
+        bulk_delete(self.session, Session, Session.uuid, uuids)
+
+    def update_all(self, sessions):
+        bulk_update(
+            self.session,
+            Session,
+            columns=[('uuid', UUIDType()), ('mobile', Boolean)],
+            rows=[(session['uuid'], session['mobile']) for session in sessions],
+            key_columns=['uuid'],
+        )

--- a/wazo_chatd/database/queries/session.py
+++ b/wazo_chatd/database/queries/session.py
@@ -1,6 +1,9 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Sequence
+from typing import Any
+
 from sqlalchemy import Boolean
 from sqlalchemy.orm import joinedload
 from sqlalchemy_utils import UUIDType
@@ -42,13 +45,13 @@ class SessionDAO:
         self.session.add(session)
         self.session.flush()
 
-    def create_all(self, sessions):
+    def create_all(self, sessions: list[Session]) -> None:
         bulk_insert(self.session, sessions)
 
-    def delete_by_uuids(self, uuids):
+    def delete_by_uuids(self, uuids: Sequence[str]) -> None:
         bulk_delete(self.session, Session, Session.uuid, uuids)
 
-    def update_all(self, sessions):
+    def update_all(self, sessions: Sequence[dict[str, Any]]) -> None:
         bulk_update(
             self.session,
             Session,

--- a/wazo_chatd/database/queries/tenant.py
+++ b/wazo_chatd/database/queries/tenant.py
@@ -1,6 +1,8 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Sequence
+
 from ...exceptions import UnknownTenantException
 from ..helpers import bulk_delete, bulk_insert
 from ..models import Tenant
@@ -23,7 +25,7 @@ class TenantDAO:
     def list_(self):
         return self.session.query(Tenant).all()
 
-    def list_uuids(self):
+    def list_uuids(self) -> set[str]:
         return {str(uuid) for (uuid,) in self.session.query(Tenant.uuid).all()}
 
     def create(self, tenant):
@@ -31,10 +33,10 @@ class TenantDAO:
         self.session.flush()
         return tenant
 
-    def create_all(self, tenants):
+    def create_all(self, tenants: list[Tenant]) -> None:
         bulk_insert(self.session, tenants)
 
-    def delete_by_uuids(self, uuids):
+    def delete_by_uuids(self, uuids: Sequence[str]) -> None:
         bulk_delete(self.session, Tenant, Tenant.uuid, uuids)
 
     def find_or_create(self, tenant_uuid):

--- a/wazo_chatd/database/queries/tenant.py
+++ b/wazo_chatd/database/queries/tenant.py
@@ -1,7 +1,8 @@
-# Copyright 2019-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ...exceptions import UnknownTenantException
+from ..helpers import bulk_delete, bulk_insert
 from ..models import Tenant
 
 
@@ -22,10 +23,19 @@ class TenantDAO:
     def list_(self):
         return self.session.query(Tenant).all()
 
+    def list_uuids(self):
+        return {str(uuid) for (uuid,) in self.session.query(Tenant.uuid).all()}
+
     def create(self, tenant):
         self.session.add(tenant)
         self.session.flush()
         return tenant
+
+    def create_all(self, tenants):
+        bulk_insert(self.session, tenants)
+
+    def delete_by_uuids(self, uuids):
+        bulk_delete(self.session, Tenant, Tenant.uuid, uuids)
 
     def find_or_create(self, tenant_uuid):
         result = self.session.get(Tenant, tenant_uuid)

--- a/wazo_chatd/database/queries/user.py
+++ b/wazo_chatd/database/queries/user.py
@@ -1,6 +1,9 @@
 # Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from collections.abc import Iterable, Sequence
+from uuid import UUID
+
 from sqlalchemy import Boolean, text
 from sqlalchemy_utils import UUIDType
 
@@ -22,7 +25,7 @@ class UserDAO:
         self.session.flush()
         return user
 
-    def create_all(self, users):
+    def create_all(self, users: list[User]) -> None:
         bulk_insert(self.session, users)
 
     def update(self, user):
@@ -50,13 +53,13 @@ class UserDAO:
     def count(self, tenant_uuids, **filter_parameters):
         return self._get_users_query(tenant_uuids, **filter_parameters).count()
 
-    def list_uuids(self):
+    def list_uuids(self) -> set[str]:
         return {str(uuid) for (uuid,) in self.session.query(User.uuid).all()}
 
-    def list_uuids_with_tenant_uuids(self):
+    def list_uuids_with_tenant_uuids(self) -> list[tuple[UUID, UUID]]:
         return self.session.query(User.uuid, User.tenant_uuid).all()
 
-    def list_dnd(self):
+    def list_dnd(self) -> dict[str, bool]:
         return {
             str(uuid): dnd
             for uuid, dnd in self.session.query(User.uuid, User.do_not_disturb).all()
@@ -66,10 +69,10 @@ class UserDAO:
         self.session.delete(user)
         self.session.flush()
 
-    def delete_by_uuids(self, uuids):
+    def delete_by_uuids(self, uuids: Sequence[str]) -> None:
         bulk_delete(self.session, User, User.uuid, uuids)
 
-    def update_dnd(self, dnd_by_uuid):
+    def update_dnd(self, dnd_by_uuid: Iterable[tuple[str, bool]]) -> None:
         bulk_update(
             self.session,
             User,

--- a/wazo_chatd/database/queries/user.py
+++ b/wazo_chatd/database/queries/user.py
@@ -1,9 +1,11 @@
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from sqlalchemy import text
+from sqlalchemy import Boolean, text
+from sqlalchemy_utils import UUIDType
 
 from ...exceptions import UnknownUserException
+from ..helpers import bulk_delete, bulk_insert, bulk_update
 from ..models import User
 
 
@@ -19,6 +21,9 @@ class UserDAO:
         self.session.add(user)
         self.session.flush()
         return user
+
+    def create_all(self, users):
+        bulk_insert(self.session, users)
 
     def update(self, user):
         self.session.add(user)
@@ -45,9 +50,33 @@ class UserDAO:
     def count(self, tenant_uuids, **filter_parameters):
         return self._get_users_query(tenant_uuids, **filter_parameters).count()
 
+    def list_uuids(self):
+        return {str(uuid) for (uuid,) in self.session.query(User.uuid).all()}
+
+    def list_uuids_with_tenant_uuids(self):
+        return self.session.query(User.uuid, User.tenant_uuid).all()
+
+    def list_dnd(self):
+        return {
+            str(uuid): dnd
+            for uuid, dnd in self.session.query(User.uuid, User.do_not_disturb).all()
+        }
+
     def delete(self, user):
         self.session.delete(user)
         self.session.flush()
+
+    def delete_by_uuids(self, uuids):
+        bulk_delete(self.session, User, User.uuid, uuids)
+
+    def update_dnd(self, dnd_by_uuid):
+        bulk_update(
+            self.session,
+            User,
+            columns=[('uuid', UUIDType()), ('do_not_disturb', Boolean)],
+            rows=list(dnd_by_uuid),
+            key_columns=['uuid'],
+        )
 
     def _get_users_query(self, tenant_uuids=None, uuids=None):
         query = self.session.query(User)

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -293,22 +293,20 @@ class Initiator:
         existing_line_ids = {id_ for id_, _, _ in lines_cached}
 
         with session_scope():
-            user_uuids = self._dao.user.list_uuids()
-            new_lines = []
-            new_line_ids = set()
+            user_uuids = set(self._dao.user.list_uuids())
+            new_lines = {}
             for id_, user_uuid, tenant_uuid in lines_missing:
                 if user_uuid not in user_uuids:
                     logger.warning('Line "%s" has no valid user "%s"', id_, user_uuid)
                     continue
-                if id_ in existing_line_ids or id_ in new_line_ids:
+                if id_ in existing_line_ids or id_ in new_lines:
                     logger.warning(
                         'Line "%s" already created. Line multi-users not supported', id_
                     )
                     continue
                 logger.debug('Create line "%s"', id_)
-                new_line_ids.add(id_)
-                new_lines.append(Line(id=id_, user_uuid=user_uuid))
-            self._dao.line.create_all(new_lines)
+                new_lines[id_] = Line(id=id_, user_uuid=user_uuid)
+            self._dao.line.create_all(list(new_lines.values()))
 
             expired_ids = []
             for id_, user_uuid, tenant_uuid in lines_expired:
@@ -329,10 +327,8 @@ class Initiator:
 
         with session_scope():
             existing = self._dao.endpoint.list_names()
-            missing = []
-            for name in endpoint_names - existing:
-                logger.debug('Create endpoint "%s"', name)
-                missing.append(Endpoint(name=name))
+            missing = [Endpoint(name=name) for name in endpoint_names - existing]
+            logger.debug('missing endpoints: %s', missing)
             self._dao.endpoint.create_all(missing)
 
     def _associate_line_endpoint(self, users):

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -290,16 +290,31 @@ class Initiator:
 
         lines_missing = lines - lines_cached
         lines_expired = lines_cached - lines
-        existing_line_ids = {id_ for id_, _, _ in lines_cached}
+        lines_modified = {
+            id_
+            for id_, _, _ in lines_missing
+            if id_ in {id_ for id_, _, _ in lines_expired}
+        }
+        logger.debug('%d lines were modified (e.g. reassigned)', len(lines_modified))
+
+        expired_ids = {id_ for id_, _, _ in lines_expired}
+        logger.debug(
+            '%d lines expired (deleted or modified) to be flushed', len(expired_ids)
+        )
+        surviving_ids = {id_ for id_, _, _ in lines_cached} - expired_ids
+        logger.debug('%d lines remain valid', len(surviving_ids))
 
         with session_scope():
             user_uuids = set(self._dao.user.list_uuids())
+
+            self._dao.line.delete_by_ids(list(expired_ids))
+
             new_lines = {}
             for id_, user_uuid, tenant_uuid in lines_missing:
                 if user_uuid not in user_uuids:
                     logger.warning('Line "%s" has no valid user "%s"', id_, user_uuid)
                     continue
-                if id_ in existing_line_ids or id_ in new_lines:
+                if id_ in surviving_ids or id_ in new_lines:
                     logger.warning(
                         'Line "%s" already created. Line multi-users not supported', id_
                     )
@@ -307,12 +322,6 @@ class Initiator:
                 logger.debug('Create line "%s"', id_)
                 new_lines[id_] = Line(id=id_, user_uuid=user_uuid)
             self._dao.line.create_all(list(new_lines.values()))
-
-            expired_ids = []
-            for id_, user_uuid, tenant_uuid in lines_expired:
-                logger.debug('Delete line "%s"', id_)
-                expired_ids.append(id_)
-            self._dao.line.delete_by_ids(expired_ids)
 
     def _add_missing_endpoints(self, users):
         endpoint_names = set()

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -140,15 +140,33 @@ class Initiator:
         return self._in_progress.is_set()
 
     def _paginate_proxy(self, callback, limit=1000, **list_params):
+        # NOTE: offset-based pagination cannot guarantee complete result set if resource set changes
         callback = partial(callback, recurse=True, limit=limit, **list_params)
         result = callback(limit=limit, offset=0)
         total = result['total']
         items = result['items']
         offset = len(items)
         while offset < total:
-            new_items = callback(offset=offset)['items']
+            response = callback(offset=offset)
+            new_items = response['items']
             items.extend(new_items)
             offset += len(new_items)
+            if not new_items:
+                logger.warning(
+                    'No new items at offset %d while paginating callback %s',
+                    offset,
+                    str(callback),
+                )
+                break
+            if response['total'] != total:
+                new_total = response['total']
+                logger.warning(
+                    'reported total changed during pagination for %s; was %d, is now %d; result set might be incorrect',
+                    str(callback),
+                    total,
+                    new_total,
+                )
+
         if len(items) != total:
             logger.warning('Fetched %d items but total was %d', len(items), total)
         return {'items': items, 'total': total}

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -3,6 +3,7 @@
 
 import logging
 import threading
+import time
 from enum import Enum, auto
 from functools import partial
 
@@ -17,14 +18,6 @@ from wazo_chatd.database.models import (
     Session,
     Tenant,
     User,
-)
-from wazo_chatd.exceptions import (
-    UnknownEndpointException,
-    UnknownLineException,
-    UnknownRefreshTokenException,
-    UnknownSessionException,
-    UnknownTenantException,
-    UnknownUserException,
 )
 
 logger = logging.getLogger(__name__)
@@ -176,6 +169,7 @@ class Initiator:
         return self._milestone_tracker.has_passed(resource, Stage.FETCHED)
 
     def initiate(self):
+        start = time.monotonic()
         self._milestone_tracker.reset()
         self._in_progress.set()
 
@@ -224,29 +218,27 @@ class Initiator:
         self.execute_post_hooks()
         self._in_progress.clear()
         self._is_initialized.set()
-        logger.info('Initialization completed')
+        logger.info(
+            'Presence initialization completed in %.2fs', time.monotonic() - start
+        )
 
     def initiate_tenants(self, tenants):
         tenants = {tenant['uuid'] for tenant in tenants}
         tenants_cached = {str(tenant.uuid) for tenant in self._dao.tenant.list_()}
 
         tenants_missing = tenants - tenants_cached
+        tenants_expired = tenants_cached - tenants
+
         with session_scope():
+            new_tenants = []
             for uuid in tenants_missing:
                 logger.debug('Create tenant "%s"', uuid)
-                tenant = Tenant(uuid=uuid)
-                self._dao.tenant.create(tenant)
+                new_tenants.append(Tenant(uuid=uuid))
+            self._dao.tenant.create_all(new_tenants)
 
-        tenants_expired = tenants_cached - tenants
-        with session_scope():
             for uuid in tenants_expired:
-                try:
-                    tenant = self._dao.tenant.get(uuid)
-                except UnknownTenantException as e:
-                    logger.warning(e)
-                    continue
                 logger.debug('Delete tenant "%s"', uuid)
-                self._dao.tenant.delete(tenant)
+            self._dao.tenant.delete_by_uuids(list(tenants_expired))
 
     def initiate_users(self, users):
         self._add_and_remove_users(users)
@@ -258,30 +250,32 @@ class Initiator:
     def _add_and_remove_users(self, users):
         users = {(user['uuid'], user['tenant_uuid']) for user in users}
         users_cached = {
-            (str(u.uuid), str(u.tenant_uuid))
-            for u in self._dao.user.list_(tenant_uuids=None)
+            (str(uuid), str(tenant_uuid))
+            for uuid, tenant_uuid in self._dao.user.list_uuids_with_tenant_uuids()
         }
 
         users_missing = users - users_cached
-        with session_scope():
-            for uuid, tenant_uuid in users_missing:
-                # Avoid race condition between init tenant and init user
-                tenant = self._dao.tenant.find_or_create(tenant_uuid)
-
-                logger.debug('Create user "%s"', uuid)
-                user = User(uuid=uuid, tenant=tenant, state='unavailable')
-                self._dao.user.create(user)
-
         users_expired = users_cached - users
+
         with session_scope():
+            # Avoid race condition between init tenant and init user
+            existing_tenants = self._dao.tenant.list_uuids()
+            missing_tenants = {t for _, t in users_missing} - existing_tenants
+            self._dao.tenant.create_all([Tenant(uuid=t) for t in missing_tenants])
+
+            new_users = []
+            for uuid, tenant_uuid in users_missing:
+                logger.debug('Create user "%s"', uuid)
+                new_users.append(
+                    User(uuid=uuid, tenant_uuid=tenant_uuid, state='unavailable')
+                )
+            self._dao.user.create_all(new_users)
+
+            expired_uuids = []
             for uuid, tenant_uuid in users_expired:
-                try:
-                    user = self._dao.user.get([tenant_uuid], uuid)
-                except UnknownUserException as e:
-                    logger.warning(e)
-                    continue
                 logger.debug('Delete user "%s"', uuid)
-                self._dao.user.delete(user)
+                expired_uuids.append(uuid)
+            self._dao.user.delete_by_uuids(expired_uuids)
 
     def _add_and_remove_lines(self, users):
         lines = {
@@ -295,94 +289,86 @@ class Initiator:
         }
 
         lines_missing = lines - lines_cached
+        lines_expired = lines_cached - lines
+        existing_line_ids = {id_ for id_, _, _ in lines_cached}
+
         with session_scope():
+            user_uuids = self._dao.user.list_uuids()
+            new_lines = []
+            new_line_ids = set()
             for id_, user_uuid, tenant_uuid in lines_missing:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                except UnknownUserException as e:
-                    logger.warning(e)
+                if user_uuid not in user_uuids:
+                    logger.warning('Line "%s" has no valid user "%s"', id_, user_uuid)
                     continue
-                if self._dao.line.find(id_):
+                if id_ in existing_line_ids or id_ in new_line_ids:
                     logger.warning(
                         'Line "%s" already created. Line multi-users not supported', id_
                     )
                     continue
-                line = Line(id=id_)
                 logger.debug('Create line "%s"', id_)
-                self._dao.user.add_line(user, line)
+                new_line_ids.add(id_)
+                new_lines.append(Line(id=id_, user_uuid=user_uuid))
+            self._dao.line.create_all(new_lines)
 
-        lines_expired = lines_cached - lines
-        with session_scope():
+            expired_ids = []
             for id_, user_uuid, tenant_uuid in lines_expired:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                    line = self._dao.line.get(id_)
-                except UnknownUserException:
-                    logger.debug('Line "%s" already deleted', id_)
-                    continue
                 logger.debug('Delete line "%s"', id_)
-                self._dao.user.remove_session(user, line)
+                expired_ids.append(id_)
+            self._dao.line.delete_by_ids(expired_ids)
 
     def _add_missing_endpoints(self, users):
-        lines = {
-            (line['id'], extract_endpoint_from_line_presence_view(line))
-            for user in users
-            for line in user['lines']
-        }
-        with session_scope():
-            for line_id, endpoint_name in lines:
+        endpoint_names = set()
+        for user in users:
+            for line in user['lines']:
+                endpoint_name = extract_endpoint_from_line_presence_view(line)
                 if not endpoint_name:
-                    logger.warning('Line "%s" doesn\'t have name', line_id)
+                    logger.warning('Line "%s" doesn\'t have name', line['id'])
                     continue
 
-                endpoint = self._dao.endpoint.find_by(name=endpoint_name)
-                if endpoint:
-                    continue
+                endpoint_names.add(endpoint_name)
 
-                logger.debug('Create endpoint "%s"', endpoint_name)
-                self._dao.endpoint.create(Endpoint(name=endpoint_name))
+        with session_scope():
+            existing = self._dao.endpoint.list_names()
+            missing = []
+            for name in endpoint_names - existing:
+                logger.debug('Create endpoint "%s"', name)
+                missing.append(Endpoint(name=name))
+            self._dao.endpoint.create_all(missing)
 
     def _associate_line_endpoint(self, users):
-        lines = {
-            (line['id'], extract_endpoint_from_line_presence_view(line))
-            for user in users
-            for line in user['lines']
-        }
+        desired = {}
+        for user in users:
+            for line in user['lines']:
+                endpoint_name = extract_endpoint_from_line_presence_view(line)
+                if endpoint_name:
+                    desired[line['id']] = endpoint_name
+
         with session_scope():
-            for line_id, endpoint_name in lines:
-                try:
-                    line = self._dao.line.get(line_id)
-                    endpoint = self._dao.endpoint.get_by(name=endpoint_name)
-                except (UnknownLineException, UnknownEndpointException):
-                    logger.debug(
-                        'Unable to associate line "%s" with endpoint "%s"',
-                        line_id,
-                        endpoint_name,
-                    )
+            cached = {line.id: line.endpoint_name for line in self._dao.line.list_()}
+            associations = []
+            for line_id, endpoint_name in desired.items():
+                if cached.get(line_id) == endpoint_name:
                     continue
                 logger.debug(
-                    'Associate line "%s" with endpoint "%s"', line.id, endpoint.name
+                    'Associate line "%s" with endpoint "%s"', line_id, endpoint_name
                 )
-                self._dao.line.associate_endpoint(line, endpoint)
+                associations.append({'id': line_id, 'endpoint_name': endpoint_name})
+            self._dao.line.associate_endpoints(associations)
 
     def _update_services_users(self, users):
-        with session_scope() as session:
-            for confd_user in users:
-                try:
-                    user = self._dao.user.get(
-                        [confd_user['tenant_uuid']], confd_user['uuid']
-                    )
-                except UnknownUserException as e:
-                    logger.warning(e)
+        desired = {user['uuid']: user['services']['dnd']['enabled'] for user in users}
+
+        with session_scope():
+            cached = self._dao.user.list_dnd()
+            changed = []
+            for uuid, do_not_disturb in desired.items():
+                if cached.get(uuid) == do_not_disturb:
                     continue
-                do_not_disturb_status = confd_user['services']['dnd']['enabled']
                 logger.debug(
-                    'Updating user "%s" DND status to "%s"',
-                    user.uuid,
-                    do_not_disturb_status,
+                    'Updating user "%s" DND status to "%s"', uuid, do_not_disturb
                 )
-                user.do_not_disturb = do_not_disturb_status
-                session.flush()
+                changed.append((uuid, do_not_disturb))
+            self._dao.user.update_dnd(changed)
 
     def initiate_sessions(self, sessions):
         self._add_and_remove_sessions(sessions)
@@ -399,38 +385,37 @@ class Initiator:
         }
 
         sessions_missing = sessions - sessions_cached
+        sessions_expired = sessions_cached - sessions
+
         with session_scope():
+            user_uuids = self._dao.user.list_uuids()
+            new_sessions = []
             for uuid, user_uuid, tenant_uuid in sessions_missing:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                except UnknownUserException:
+                if user_uuid not in user_uuids:
                     logger.debug('Session "%s" has no valid user "%s"', uuid, user_uuid)
                     continue
 
                 logger.debug('Create session "%s" for user "%s"', uuid, user_uuid)
-                session = Session(uuid=uuid, user_uuid=user_uuid)
-                self._dao.user.add_session(user, session)
+                new_sessions.append(Session(uuid=uuid, user_uuid=user_uuid))
+            self._dao.session.create_all(new_sessions)
 
-        sessions_expired = sessions_cached - sessions
-        with session_scope():
+            expired_uuids = []
             for uuid, user_uuid, tenant_uuid in sessions_expired:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                    session = self._dao.session.get(uuid)
-                except (UnknownUserException, UnknownSessionException) as e:
-                    logger.warning(e)
-                    continue
-
                 logger.debug('Delete session "%s" for user "%s"', uuid, user_uuid)
-                self._dao.user.remove_session(user, session)
+                expired_uuids.append(uuid)
+            self._dao.session.delete_by_uuids(expired_uuids)
 
     def _update_sessions(self, sessions):
+        sessions_by_uuid = {session['uuid']: session for session in sessions}
         with session_scope():
-            for session in sessions:
-                cached_session = self._dao.session.find(session['uuid'])
-                if cached_session and session['mobile'] != cached_session.mobile:
-                    cached_session.mobile = session['mobile']
-                    self._dao.session.update(cached_session)
+            updates = []
+            for cached_session in self._dao.session.list_():
+                session = sessions_by_uuid.get(str(cached_session.uuid))
+                if session is not None and session['mobile'] != cached_session.mobile:
+                    updates.append(
+                        {'uuid': cached_session.uuid, 'mobile': session['mobile']}
+                    )
+            self._dao.session.update_all(updates)
 
     def initiate_refresh_tokens(self, tokens):
         self._add_and_remove_refresh_tokens(tokens)
@@ -447,11 +432,13 @@ class Initiator:
         }
 
         tokens_missing = tokens - tokens_cached
+        tokens_expired = tokens_cached - tokens
+
         with session_scope():
+            user_uuids = self._dao.user.list_uuids()
+            new_tokens = []
             for client_id, user_uuid, tenant_uuid in tokens_missing:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                except UnknownUserException:
+                if user_uuid not in user_uuids:
                     logger.debug(
                         'Refresh token "%s" has no valid user "%s"',
                         client_id,
@@ -462,69 +449,77 @@ class Initiator:
                 logger.debug(
                     'Create refresh token "%s" for user "%s"', client_id, user_uuid
                 )
-                token = RefreshToken(client_id=client_id, user_uuid=user_uuid)
-                self._dao.user.add_refresh_token(user, token)
+                new_tokens.append(
+                    RefreshToken(client_id=client_id, user_uuid=user_uuid)
+                )
+            self._dao.refresh_token.create_all(new_tokens)
 
-        tokens_expired = tokens_cached - tokens
-        with session_scope():
+            expired_keys = []
             for client_id, user_uuid, tenant_uuid in tokens_expired:
-                try:
-                    user = self._dao.user.get([tenant_uuid], user_uuid)
-                    token = self._dao.refresh_token.get(user_uuid, client_id)
-                except (UnknownUserException, UnknownRefreshTokenException) as e:
-                    logger.warning(e)
-                    continue
-
                 logger.debug(
                     'Delete refresh token "%s" for user "%s"', client_id, user_uuid
                 )
-                self._dao.user.remove_refresh_token(user, token)
+                expired_keys.append((client_id, user_uuid))
+            self._dao.refresh_token.delete_by_keys(expired_keys)
 
     def _update_refresh_tokens(self, tokens):
+        tokens_by_key = {
+            (token['user_uuid'], token['client_id']): token for token in tokens
+        }
         with session_scope():
-            for token in tokens:
-                cached_token = self._dao.refresh_token.find(
-                    token['user_uuid'], token['client_id']
-                )
-                if cached_token and token['mobile'] != cached_token.mobile:
-                    cached_token.mobile = token['mobile']
-                    self._dao.refresh_token.update(cached_token)
+            updates = []
+            for cached_token in self._dao.refresh_token.list_():
+                key = (str(cached_token.user_uuid), cached_token.client_id)
+                token = tokens_by_key.get(key)
+                if token is not None and token['mobile'] != cached_token.mobile:
+                    updates.append(
+                        {
+                            'client_id': cached_token.client_id,
+                            'user_uuid': cached_token.user_uuid,
+                            'mobile': token['mobile'],
+                        }
+                    )
+            self._dao.refresh_token.update_all(updates)
 
     def initiate_endpoints(self, events):
+        endpoints = {}
+        for event in events:
+            if event.get('Event') != 'DeviceStateChange':
+                continue
+
+            endpoint_name = event['Device']
+            if endpoint_name.startswith('Custom:'):
+                continue
+
+            state = DEVICE_STATE_MAP.get(event['State'], 'unavailable')
+            logger.debug('Create endpoint "%s" with state "%s"', endpoint_name, state)
+            endpoints[endpoint_name] = Endpoint(name=endpoint_name, state=state)
+
         with session_scope():
             logger.debug('Delete all endpoints')
             self._dao.endpoint.delete_all()
-            for event in events:
-                if event.get('Event') != 'DeviceStateChange':
-                    continue
-
-                endpoint_name = event['Device']
-                if endpoint_name.startswith('Custom:'):
-                    continue
-
-                endpoint_args = {
-                    'name': endpoint_name,
-                    'state': DEVICE_STATE_MAP.get(event['State'], 'unavailable'),
-                }
-                logger.debug(
-                    'Create endpoint "%s" with state "%s"',
-                    endpoint_args['name'],
-                    endpoint_args['state'],
-                )
-                self._dao.endpoint.create(Endpoint(**endpoint_args))
+            self._dao.endpoint.create_all(list(endpoints.values()))
 
     def initiate_channels(self, events):
         with session_scope():
             logger.debug('Delete all channels')
             self._dao.channel.delete_all()
+
+            line_id_by_endpoint = {
+                line.endpoint_name: line.id
+                for line in self._dao.line.list_()
+                if line.endpoint_name
+            }
+
+            channels = {}
             for event in events:
                 if event.get('Event') != 'CoreShowChannel':
                     continue
 
                 channel_name = event['Channel']
                 endpoint_name = extract_endpoint_from_channel(channel_name)
-                line = self._dao.line.find_by(endpoint_name=endpoint_name)
-                if not line:
+                line_id = line_id_by_endpoint.get(endpoint_name)
+                if line_id is None:
                     logger.debug(
                         'Unknown line with endpoint "%s" for channel "%s"',
                         endpoint_name,
@@ -536,14 +531,9 @@ class Initiator:
                 if event['ChanVariable'].get('XIVO_ON_HOLD') == '1':
                     state = 'holding'
 
-                channel_args = {
-                    'name': channel_name,
-                    'state': state,
-                }
-                logger.debug(
-                    'Create channel "%s" with state "%s"',
-                    channel_args['name'],
-                    channel_args['state'],
+                logger.debug('Create channel "%s" with state "%s"', channel_name, state)
+                channels[channel_name] = Channel(
+                    name=channel_name, state=state, line_id=line_id
                 )
-                channel = Channel(**channel_args)
-                self._dao.line.add_channel(line, channel)
+
+            self._dao.channel.create_all(list(channels.values()))

--- a/wazo_chatd/plugins/presences/initiator.py
+++ b/wazo_chatd/plugins/presences/initiator.py
@@ -323,7 +323,7 @@ class Initiator:
         logger.debug('%d lines remain valid', len(surviving_ids))
 
         with session_scope():
-            user_uuids = set(self._dao.user.list_uuids())
+            user_uuids = self._dao.user.list_uuids()
 
             self._dao.line.delete_by_ids(list(expired_ids))
 

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -183,3 +183,36 @@ def test_initiate_fetches_users_with_line_presence_view(initiator: Initiator):
     ]
     assert len(users_calls) == 1
     assert users_calls[0].kwargs.get('view') == 'line_presence'
+
+
+def test_add_and_remove_lines_reassigns_line_to_new_user(initiator: Initiator):
+    tenant_uuid = 'tenant-1'
+    user_a = 'user-a'
+    user_b = 'user-b'
+    line_id = 5
+
+    cached_line = mock.Mock(id=line_id, user_uuid=user_a, tenant_uuid=tenant_uuid)
+    initiator._dao.line.list_.return_value = [cached_line]
+    initiator._dao.user.list_uuids.return_value = {user_a, user_b}
+
+    users = [
+        {'uuid': user_a, 'tenant_uuid': tenant_uuid, 'lines': []},
+        {'uuid': user_b, 'tenant_uuid': tenant_uuid, 'lines': [{'id': line_id}]},
+    ]
+
+    with mock.patch('wazo_chatd.plugins.presences.initiator.session_scope'):
+        initiator._add_and_remove_lines(users)
+
+    deleted_ids = set()
+    for call in initiator._dao.line.delete_by_ids.call_args_list:
+        (ids,) = call.args
+        deleted_ids.update(ids)
+
+    created_ids: set = set()
+    for call in initiator._dao.line.create_all.call_args_list:
+        (lines,) = call.args
+        created_ids.update(line.id for line in lines)
+
+    # The line is still desired (moved to user B), so it must not be silently
+    # lost: kept/reassigned (not deleted) or deleted and recreated.
+    assert line_id not in deleted_ids or line_id in created_ids

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -154,6 +154,28 @@ def test_paginate_proxy_forwards_list_params(initiator: Initiator):
         assert call.kwargs['recurse'] is True
 
 
+def test_paginate_proxy_terminates_when_total_shrinks(initiator: Initiator):
+    # First page reports total=6 and returns 2 items; the dataset then shrinks
+    # so later pages come back empty. offset stays at 2 < 6, so a naive loop
+    # never advances and spins forever.
+    first_page = {'items': [{'id': 1}, {'id': 2}], 'total': 6}
+    calls = 0
+
+    def paginated_callback(recurse, limit, offset):
+        nonlocal calls
+        calls += 1
+        if calls > 10:
+            raise AssertionError('pagination did not terminate')
+        if offset == 0:
+            return first_page
+        return {'items': [], 'total': 2}
+
+    callback_mock = mock.Mock(side_effect=paginated_callback)
+    result = initiator._paginate_proxy(callback_mock, limit=2)
+
+    assert result['items'] == [{'id': 1}, {'id': 2}]
+
+
 def test_initiate_fetches_users_with_line_presence_view(initiator: Initiator):
     initiator._auth = mock.MagicMock()
     initiator._amid = mock.MagicMock()

--- a/wazo_chatd/plugins/presences/tests/test_initiator.py
+++ b/wazo_chatd/plugins/presences/tests/test_initiator.py
@@ -19,7 +19,7 @@ from wazo_chatd.plugins.presences.initiator import (
 @pytest.fixture
 def initiator():
     return Initiator(
-        dao=mock.create_autospec(DAO, instance=True),
+        dao=mock.create_autospec(DAO(), instance=True),
         auth=mock.create_autospec(AuthClient, instance=True),
         amid=mock.create_autospec(AmidClient, instance=True),
         confd=mock.create_autospec(ConfdClient, instance=True),
@@ -64,6 +64,51 @@ def test_extract_endpoint_from_line_without_name():
 
 def test_extract_endpoint_from_line_without_endpoint():
     assert extract_endpoint_from_line({'name': 'line-name'}) is None
+
+
+def test_initiate_endpoints_dedupes_duplicate_devices(initiator: Initiator):
+    events = [
+        {'Event': 'DeviceStateChange', 'Device': 'PJSIP/abc', 'State': 'INUSE'},
+        {'Event': 'DeviceStateChange', 'Device': 'PJSIP/abc', 'State': 'UNAVAILABLE'},
+    ]
+
+    with mock.patch('wazo_chatd.plugins.presences.initiator.session_scope'):
+        initiator.initiate_endpoints(events)
+
+    initiator._dao.endpoint.create_all.assert_called_once()
+    (endpoints,) = initiator._dao.endpoint.create_all.call_args[0]
+    assert len(endpoints) == 1
+    assert endpoints[0].name == 'PJSIP/abc'
+    assert endpoints[0].state == 'unavailable'
+
+
+def test_initiate_channels_dedupes_duplicate_channels(initiator: Initiator):
+    line = mock.Mock(id=42, endpoint_name='PJSIP/abc')
+    initiator._dao.line.list_.return_value = [line]
+    events = [
+        {
+            'Event': 'CoreShowChannel',
+            'Channel': 'PJSIP/abc-00000001',
+            'ChannelStateDesc': 'Up',
+            'ChanVariable': {},
+        },
+        {
+            'Event': 'CoreShowChannel',
+            'Channel': 'PJSIP/abc-00000001',
+            'ChannelStateDesc': 'Up',
+            'ChanVariable': {},
+        },
+    ]
+
+    with mock.patch('wazo_chatd.plugins.presences.initiator.session_scope'):
+        initiator.initiate_channels(events)
+
+    initiator._dao.channel.create_all.assert_called_once()
+    (channels,) = initiator._dao.channel.create_all.call_args[0]
+    assert len(channels) == 1
+    assert channels[0].name == 'PJSIP/abc-00000001'
+    assert channels[0].state == 'talking'
+    assert channels[0].line_id == 42
 
 
 def test_paginate_proxy(initiator: Initiator):


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-chatd/pull/201

## Summary

Reconcile presence-init writes in bulk, replacing the per-row create/update/delete in the presence initiator.

- Bulk DAO operations: chunked `bulk_insert`, set-based `UPDATE ... FROM VALUES`, and chunked `IN` deletes — routed through the DAO's injected session.
- Each resource is reconciled with a single diff against the cached state; only the rows that changed are written.
- Endpoints and channels are de-duplicated by name before insert.
- Total presence-initialization wall-time is logged at `INFO`.

## Tests

`test_presence_initialization` integration suite passes (10/10); unit tests and pre-commit (flake8/black/isort/mypy) clean.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core presence DB reconciliation at startup (users, lines, sessions, tokens); behavior changes are covered by integration tests but incorrect bulk reconcile could skew presence state until the next init.
> 
> **Overview**
> **Replaces per-row presence initialization** with set-based reconciliation and chunked bulk SQL, aimed at faster startup and correct line/session/token sync.
> 
> Adds shared **`bulk_insert` / `bulk_update` / `bulk_delete`** helpers (1k-row batches) and extends tenant, user, line, session, refresh token, endpoint, and channel DAOs with **`create_all`**, targeted bulk deletes/updates, and lightweight cache queries (`list_uuids`, `list_dnd`, etc.). The **presence `Initiator`** diffs remote state against the DB and only writes deltas; **line moves** are handled by flushing expired line IDs then recreating missing ones; **DND** and **`mobile`** on sessions/tokens use bulk updates; **endpoints and channels** are keyed by name to drop duplicates before insert. **Pagination** now stops on empty pages and warns when totals drift; total init time is logged at **INFO**.
> 
> **Tests** cover bulk endpoint defaults, mobile flag refresh, dropped lines, and cross-user line reassignment, plus unit tests for dedup and pagination edge cases. **mypy** enforces complete defs on the new bulk DAO surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def9cc3e642de6e1c9af30c65cbf1d509c0e9261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->