### PR TITLE
ITEM-391-typing

### DIFF
--- a/wazo_chatd/plugins/connectors/http.py
+++ b/wazo_chatd/plugins/connectors/http.py
@@ -221,7 +221,7 @@ class UserMeIdentityListResource(AuthResource):
     def get(self) -> tuple[dict[str, Any], int]:
         params = user_identity_list_request_schema.load(request.args)
         user_uuid = str(token.user_uuid)
-        tenant_uuids = [token.tenant_uuid]
+        tenant_uuids = get_tenant_uuids(recurse=False)
 
         if params['room_uuid'] is not None:
             room_uuid = str(params['room_uuid'])

--- a/wazo_chatd/plugins/connectors/router.py
+++ b/wazo_chatd/plugins/connectors/router.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from typing import TYPE_CHECKING
 
-from xivo.status import Status
+from xivo.status import Status, StatusDict
 
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict, MessageContext
 from wazo_chatd.plugins.connectors.exceptions import (
@@ -236,11 +236,13 @@ class ConnectorRouter:
                 context.room, context.message, identity
             )
 
-    def provide_status(self, status: dict[str, dict[str, str | int]]) -> None:
+    def provide_status(self, status: StatusDict) -> None:
         delivery = self._delivery_runner
         listener = self._listener_runner
         both_running = delivery.is_running and listener.is_running
-        status['connectors'] = {
+        # xivo's StatusDict types values as str, but the status endpoint also
+        # serializes numeric counters reported here.
+        status['connectors'] = {  # type: ignore[assignment]
             'status': Status.ok if both_running else Status.fail,
             'backends_registered': len(self._registry.available_backends()),
             'in_flight': delivery.in_flight_count,

--- a/wazo_chatd/plugins/connectors/router.py
+++ b/wazo_chatd/plugins/connectors/router.py
@@ -240,9 +240,7 @@ class ConnectorRouter:
         delivery = self._delivery_runner
         listener = self._listener_runner
         both_running = delivery.is_running and listener.is_running
-        # xivo's StatusDict types values as str, but the status endpoint also
-        # serializes numeric counters reported here.
-        status['connectors'] = {  # type: ignore[assignment]
+        status['connectors'] = {
             'status': Status.ok if both_running else Status.fail,
             'backends_registered': len(self._registry.available_backends()),
             'in_flight': delivery.in_flight_count,

--- a/wazo_chatd/plugins/rooms/schemas.py
+++ b/wazo_chatd/plugins/rooms/schemas.py
@@ -89,7 +89,7 @@ class MessageListRequestSchema(_ListSchema):
     @validates_schema
     def search_or_distinct(self, data, **kwargs):
         if not data.get('search') and not data.get('distinct'):
-            raise ValidationError('Missing search or distinct')
+            raise ValidationError({'_schema': 'Missing search or distinct'})
 
 
 class RoomListRequestSchema(Schema):


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/183
linters will pass once xivo-lib-python will be merged

Why: tox -e linters failed on type mismatches.

- rooms/schemas.py: xivo's ValidationError takes a dict (it becomes the
  response details), not a str
- connectors/router.py: type provide_status with xivo's StatusDict so it
  matches StatusProvider; the status dict reports numeric counters that
  StatusDict types as str, hence the ignore
- connectors/http.py: token.tenant_uuid is str | None; use
  get_tenant_uuids() which returns list[str]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small annotation and validation-error shape changes; tenant lookup for `/users/me/identities` now uses the same helper as other connector routes.
> 
> **Overview**
> Fixes **type-checker failures** (`tox -e linters`) by aligning a few call sites with updated **xivo-lib-python** APIs (depends on the related xivo PR).
> 
> **`UserMeIdentityListResource`** now resolves tenants via **`get_tenant_uuids(recurse=False)`** instead of wrapping **`token.tenant_uuid`**, so the value is always a **`list[str]`** and matches other connector HTTP handlers.
> 
> **`ConnectorRouter.provide_status`** is annotated with **`StatusDict`** from **`xivo.status`** so it matches the **`StatusProvider`** contract (replacing a loose nested dict type).
> 
> **`MessageListRequestSchema`** raises **`ValidationError`** with a **`{'_schema': '...'}`** dict rather than a bare string, matching xivo’s expected error shape for schema validation responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52d0cc3ed9d9eac23a6c106e322766449c5eb73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->