### PR TITLE
ITEM-447-dynamic-thread-pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 26.08
+
+* New `rest_api.min_threads` option: threads kept ready at all times.
+  `max_threads` is now a ceiling the pool grows to under load, not a fixed
+  thread count.
+
 ## 26.07
 
 * New endpoints:

--- a/etc/wazo-chatd/config.yml
+++ b/etc/wazo-chatd/config.yml
@@ -27,10 +27,16 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token, Wazo-Tenant]
 
-  # Maximum of concurrent threads processing requests
+  # Minimum of concurrent threads processing requests. This many threads
+  # (and database connections) are kept ready at all times.
+  min_threads: 10
+
+  # Maximum of concurrent threads processing requests. The number of threads
+  # (and database connections) scales with demand between min_threads and
+  # max_threads.
   # See the performance documentation for more details
   # https://wazo-platform.org/uc-doc/system/performance/
-  max_threads: 10
+  max_threads: 100
 
 # Authentication server connection settings
 auth:

--- a/wazo_chatd/config.py
+++ b/wazo_chatd/config.py
@@ -25,7 +25,8 @@ _DEFAULT_CONFIG = {
             'enabled': True,
             'allow_headers': ['Content-Type', 'X-Auth-Token', 'Wazo-Tenant'],
         },
-        'max_threads': 10,
+        'min_threads': 10,
+        'max_threads': 100,
     },
     'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-chatd',
     'auth': {

--- a/wazo_chatd/controller.py
+++ b/wazo_chatd/controller.py
@@ -24,14 +24,17 @@ from .thread_manager import ThreadManager
 
 logger = logging.getLogger(__name__)
 
+DB_POOL_SPARE_CONN = 10
+
 
 class Controller:
     def __init__(self, config):
+        min_threads = config['rest_api']['min_threads']
+        max_threads = config['rest_api']['max_threads']
         init_db(
             config['db_uri'],
-            pool_size=config['rest_api']['min_threads'],
-            max_overflow=config['rest_api']['max_threads']
-            - config['rest_api']['min_threads'],
+            pool_size=min_threads,
+            max_overflow=max_threads - min_threads + DB_POOL_SPARE_CONN,
         )
         self._service_discovery_args = [
             'wazo-chatd',

--- a/wazo_chatd/controller.py
+++ b/wazo_chatd/controller.py
@@ -27,7 +27,12 @@ logger = logging.getLogger(__name__)
 
 class Controller:
     def __init__(self, config):
-        init_db(config['db_uri'], pool_size=config['rest_api']['max_threads'])
+        init_db(
+            config['db_uri'],
+            pool_size=config['rest_api']['min_threads'],
+            max_overflow=config['rest_api']['max_threads']
+            - config['rest_api']['min_threads'],
+        )
         self._service_discovery_args = [
             'wazo-chatd',
             config['uuid'],

--- a/wazo_chatd/database/helpers.py
+++ b/wazo_chatd/database/helpers.py
@@ -28,8 +28,14 @@ def _chunked(items: Sequence[T], size: int) -> Iterator[Sequence[T]]:
         yield items[start : start + size]
 
 
-def init_db(db_uri, echo=False, pool_size=16):
-    engine = create_engine(db_uri, echo=echo, pool_size=pool_size, pool_pre_ping=True)
+def init_db(db_uri, echo=False, pool_size=16, max_overflow=10):
+    engine = create_engine(
+        db_uri,
+        echo=echo,
+        pool_size=pool_size,
+        max_overflow=max_overflow,
+        pool_pre_ping=True,
+    )
     Session.configure(bind=engine)
 
 

--- a/wazo_chatd/http_server.py
+++ b/wazo_chatd/http_server.py
@@ -66,10 +66,11 @@ class CoreRestApi:
         bind_addr = (self.config['listen'], self.config['port'])
 
         wsgi_app = wsgi.WSGIPathInfoDispatcher({'/': app})
-        self.server = wsgi.WSGIServer(
+        self.server = wsgi.DynamicWSGIServer(
             bind_addr=bind_addr,
             wsgi_app=wsgi_app,
-            numthreads=self.config['max_threads'],
+            numthreads=self.config['min_threads'],
+            max=self.config['max_threads'],
         )
         if self.config['certificate'] and self.config['private_key']:
             logger.warning(


### PR DESCRIPTION
Note: lib-python must be merged first to make linter pass ...(todo: update zuul to use depends-on for typing)

Depends-on: https://github.com/wazo-platform/xivo-lib-python/pull/187

Why: max_threads was a fixed thread count spawned at startup, wasting
idle threads and DB connections on quiet systems. The pool now grows
and shrinks between the new min_threads setting and max_threads, which
becomes a real ceiling.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default concurrency and DB connection limits for all REST traffic; behavior depends on the merged xivo-lib-python DynamicWSGIServer implementation.
> 
> **Overview**
> Replaces a **fixed** REST worker thread count with a **dynamic pool** that stays at `rest_api.min_threads` when idle and can grow up to `rest_api.max_threads` under load. Defaults move from a single `max_threads: 10` to **`min_threads: 10`** and **`max_threads: 100`**.
> 
> The HTTP stack switches from `WSGIServer` to **`DynamicWSGIServer`** (xivo-lib-python), passing `min_threads` as the initial pool size and `max_threads` as the cap. **SQLAlchemy** is aligned via `init_db`: `pool_size` matches `min_threads`, and **`max_overflow`** is set from the thread ceiling plus a small spare (`DB_POOL_SPARE_CONN`) so connections can scale with demand instead of provisioning `max_threads` connections at startup.
> 
> Config samples, built-in defaults, and the changelog document that **`max_threads` is now a ceiling**, not the number of threads always running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de4eead2dadee056318b0905c79872f45c5edb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->