### PR TITLE
Release DB session after populating connector store

### DIFF
--- a/integration_tests/suite/test_connector_store.py
+++ b/integration_tests/suite/test_connector_store.py
@@ -1,0 +1,36 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from wazo_test_helpers import until
+
+from .helpers.base import ConnectorIntegrationTest, use_asset
+
+
+@use_asset('connectors')
+class TestStorePopulate(ConnectorIntegrationTest):
+    def test_populate_does_not_leak_open_transaction(self):
+        def store_populated():
+            assert 'Populated connector store' in self.asset_cls.service_logs('chatd')
+
+        until.assert_(store_populated, timeout=30)
+
+        def no_leaked_transaction():
+            leaked = (
+                self._session.execute(
+                    text(
+                        "SELECT query FROM pg_stat_activity"
+                        " WHERE state LIKE 'idle in transaction%'"
+                        " AND query LIKE '%chatd_user_identity%'"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            # release our own transaction so it cannot show up as leaked
+            self._session.rollback()
+            assert leaked == []
+
+        until.assert_(no_leaked_transaction, timeout=10)

--- a/wazo_chatd/plugins/connectors/router.py
+++ b/wazo_chatd/plugins/connectors/router.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from xivo.status import Status, StatusDict
 
+from wazo_chatd.database.helpers import session_scope
 from wazo_chatd.plugin_helpers.dependencies import ConfigDict, MessageContext
 from wazo_chatd.plugins.connectors.exceptions import (
     AuthServiceUnavailableException,
@@ -90,7 +91,8 @@ class ConnectorRouter:
 
     def _populate_store(self) -> None:
         try:
-            tenant_backends = self._dao.user_identity.list_tenant_backends()
+            with session_scope():
+                tenant_backends = self._dao.user_identity.list_tenant_backends()
             self._store.populate(tenant_backends)
         except Exception:
             logger.exception('Failed to populate connector store')


### PR DESCRIPTION
## Summary

Since the connectors plugin landed, `ConnectorRouter._populate_store()` (run in the one-shot `connector-router-populate` thread on first token renewal) queried `chatd_user_identity` through the thread-local scoped session and exited without commit/rollback/`Session.remove()`. The connection stayed **idle in transaction**, holding an `ACCESS SHARE` lock on `chatd_user_identity` for the lifetime of the process.

Any operation needing `ACCESS EXCLUSIVE` on that table then blocked until wazo-chatd was killed — notably the `TRUNCATE` issued by `xivo-master-slave-db-replication` on HA slaves, which is how this was noticed (replication hanging until wazo-chatd was killed on the slave, even with presence initialization long completed).

The failure path was worse: `store.populate()` performs wazo-auth HTTP fetches while the transaction is open, and any exception leaves the transaction open the same way while `is_populated` stays False, so every subsequent token renewal leaks another connection.

The fix scopes the DB read with `session_scope()` and releases it before `store.populate()` runs.

## Tests

New integration test (`connectors` asset) waits for the store population log line, then asserts no `idle in transaction` session remains on the populate query. Verified both ways:
- with the fix: **1 passed**
- with the fix reverted (negative control): **1 failed**, reporting the leaked `SELECT DISTINCT ... FROM chatd_user_identity` transaction

Also reproduced the original symptom end-to-end before the fix: emulated the replication script's `BEGIN; TRUNCATE <all tables>; COPY; COMMIT` against the integration DB — it blocked behind the leaked lock (`wait_event_type=Lock`) and completed as soon as chatd was killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches connector startup and DB session lifecycle on a background thread; incorrect scoping could affect populate behavior, but the change is narrow and guarded by an integration test for the leak.
> 
> **Overview**
> Fixes a long-lived **idle in transaction** session left open by the background `connector-router-populate` thread when it read `chatd_user_identity` and then called `store.populate()` (including wazo-auth HTTP work) without closing the scoped SQLAlchemy session.
> 
> **`ConnectorRouter._populate_store()`** now wraps only `list_tenant_backends()` in **`session_scope()`**, so the transaction ends and the connection is returned before population and on errors, avoiding **`ACCESS SHARE`** locks that could block HA replication **`TRUNCATE`** on that table.
> 
> Adds a **`connectors`** integration test that waits for store population and asserts no `idle in transaction` query against `chatd_user_identity` remains in `pg_stat_activity`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a47a2aa54c80136e87aaf80cf7e1629e06742c79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->